### PR TITLE
テーマ切り替え機能: 和モダン / デフォルトの選択

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,43 +3,140 @@
 /* ダークモードをclassベースに変更 */
 @custom-variant dark (&:where(.dark, .dark *));
 
-/* 和モダン配色 */
+/* ===========================================
+   カラースキーム: 共通変数
+   =========================================== */
 :root {
+  /* デフォルトは和モダン */
   /* 基本色 */
-  --sumi: #2d2d2d;           /* 墨色 - テキスト */
-  --kinari: #f7f4ef;         /* 生成り - 背景 */
-  --shiro: #fdfbf7;          /* 白 - カード背景 */
-
+  --color-text: #2d2d2d;
+  --color-bg: #f7f4ef;
+  --color-card: #fdfbf7;
+  
   /* アクセント色 */
-  --shu: #c53d43;            /* 朱色 - プライマリ */
-  --shu-light: #e85d63;      /* 朱色（明るめ） */
-  --ai: #2b4b6f;             /* 藍色 - セカンダリ */
-  --matcha: #6b7b3c;         /* 抹茶色 */
-  --kitsune: #c18a40;        /* 狐色（金茶） */
-
-  /* 淡い色 */
-  --sakura: #f5e6e8;         /* 桜色 */
-  --wasurenagusa: #e6eff5;   /* 勿忘草色 */
-  --wakakusa: #e8f0e4;       /* 若草色 */
-
-  /* グレー */
-  --nezumi: #7d7d7d;         /* 鼠色 */
-  --hai: #9e9e9e;            /* 灰色 */
-  --gofun: #f0ebe1;          /* 胡粉（薄いベージュ） */
+  --color-primary: #c53d43;
+  --color-primary-hover: #e85d63;
+  --color-secondary: #2b4b6f;
+  --color-accent: #c18a40;
+  
+  /* ボーダー・グレー */
+  --color-border: #f0ebe1;
+  --color-muted: #7d7d7d;
+  --color-muted-light: #9e9e9e;
+  
+  /* ステータス色 */
+  --color-success-bg: #e8f0e4;
+  --color-success-text: #6b7b3c;
+  --color-warning-bg: #fff8e1;
+  --color-warning-text: #c18a40;
+  --color-error-bg: #f5e6e8;
+  --color-error-text: #c53d43;
+  
+  /* 優先度バッジ */
+  --color-priority-high-bg: #f5e6e8;
+  --color-priority-high-text: #c53d43;
+  --color-priority-normal-bg: #e6eff5;
+  --color-priority-normal-text: #2b4b6f;
+  --color-priority-low-bg: #f0ebe1;
+  --color-priority-low-text: #7d7d7d;
 
   /* Tailwind互換 */
   --foreground-rgb: 45, 45, 45;
   --background-rgb: 247, 244, 239;
+  
+  /* 和モダン専用（後方互換） */
+  --sumi: #2d2d2d;
+  --kinari: #f7f4ef;
+  --shiro: #fdfbf7;
+  --shu: #c53d43;
+  --shu-light: #e85d63;
+  --ai: #2b4b6f;
+  --matcha: #6b7b3c;
+  --kitsune: #c18a40;
+  --sakura: #f5e6e8;
+  --wasurenagusa: #e6eff5;
+  --wakakusa: #e8f0e4;
+  --nezumi: #7d7d7d;
+  --hai: #9e9e9e;
+  --gofun: #f0ebe1;
 }
 
+/* ===========================================
+   カラースキーム: デフォルト（オレンジ系）
+   =========================================== */
+.default-scheme {
+  --color-text: #1f2937;
+  --color-bg: #f3f4f6;
+  --color-card: #ffffff;
+  
+  --color-primary: #f97316;
+  --color-primary-hover: #ea580c;
+  --color-secondary: #3b82f6;
+  --color-accent: #fbbf24;
+  
+  --color-border: #e5e7eb;
+  --color-muted: #6b7280;
+  --color-muted-light: #9ca3af;
+  
+  --color-success-bg: #dcfce7;
+  --color-success-text: #166534;
+  --color-warning-bg: #fef3c7;
+  --color-warning-text: #92400e;
+  --color-error-bg: #fee2e2;
+  --color-error-text: #dc2626;
+  
+  --color-priority-high-bg: #fee2e2;
+  --color-priority-high-text: #dc2626;
+  --color-priority-normal-bg: #dbeafe;
+  --color-priority-normal-text: #1d4ed8;
+  --color-priority-low-bg: #f3f4f6;
+  --color-priority-low-text: #6b7280;
+  
+  /* Tailwind互換 */
+  --foreground-rgb: 31, 41, 55;
+  --background-rgb: 243, 244, 246;
+  
+  /* 和モダン変数をデフォルトにマッピング */
+  --sumi: #1f2937;
+  --kinari: #f3f4f6;
+  --shiro: #ffffff;
+  --shu: #f97316;
+  --shu-light: #ea580c;
+  --ai: #3b82f6;
+  --matcha: #166534;
+  --kitsune: #fbbf24;
+  --sakura: #fee2e2;
+  --wasurenagusa: #dbeafe;
+  --wakakusa: #dcfce7;
+  --nezumi: #6b7280;
+  --hai: #9ca3af;
+  --gofun: #e5e7eb;
+}
+
+/* ダークモード */
 .dark {
+  --color-text: #f1f5f9;
+  --color-bg: #0f172a;
+  --color-card: #1e293b;
+  
+  --color-border: #334155;
+  --color-muted: #94a3b8;
+  --color-muted-light: #64748b;
+  
   --foreground-rgb: 241, 245, 249;
   --background-rgb: 15, 23, 42;
+  
+  --kinari: #0f172a;
+  --shiro: #1e293b;
+  --gofun: #334155;
+  --nezumi: #94a3b8;
+  --hai: #64748b;
+  --sumi: #f1f5f9;
 }
 
 body {
-  color: var(--sumi);
-  background: var(--kinari);
+  color: var(--color-text);
+  background: var(--color-bg);
   font-feature-settings: "palt";
 }
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,14 +3,14 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/components/AuthProvider';
 import { useRouter } from 'next/navigation';
-import { Crown, ArrowLeft, Copy, Check, Key, Bell, Loader2, Download, Tag, Layers, Trash2, Plus, Pencil, X, RotateCcw, ChevronDown, ChevronUp, Sun, Moon, Monitor } from 'lucide-react';
+import { Crown, ArrowLeft, Copy, Check, Key, Bell, Loader2, Download, Tag, Layers, Trash2, Plus, Pencil, X, RotateCcw, ChevronDown, ChevronUp, Sun, Moon, Monitor, Palette } from 'lucide-react';
 import { useTheme } from '@/components/ThemeProvider';
 import Link from 'next/link';
 import { Category, ComparisonGroup } from '@/types';
 
 export default function SettingsPage() {
   const { user, token, loading } = useAuth();
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, colorScheme, setColorScheme } = useTheme();
   const router = useRouter();
   const [copied, setCopied] = useState(false);
   const [displayToken, setDisplayToken] = useState<string | null>(null);
@@ -223,20 +223,20 @@ export default function SettingsPage() {
 
   if (loading || !user) {
     return (
-      <div className="min-h-screen bg-gray-100 dark:bg-slate-900 flex items-center justify-center">
-        <div className="text-gray-500 dark:text-gray-400 dark:text-gray-500">読み込み中...</div>
+      <div className="min-h-screen bg-[var(--color-bg)] flex items-center justify-center">
+        <div className="text-[var(--color-muted)]">読み込み中...</div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-100 dark:bg-slate-900">
+    <div className="min-h-screen bg-[var(--color-bg)]">
       {/* ヘッダー */}
-      <header className="bg-gradient-to-r from-amber-500 to-orange-500 text-white shadow-lg">
-        <div className="max-w-4xl mx-auto px-4 py-6">
-          <div className="flex items-center gap-3">
-            <Crown size={32} className="text-yellow-300" />
-            <h1 className="text-2xl font-bold">物欲王</h1>
+      <header className="bg-[var(--color-secondary)] text-white">
+        <div className="max-w-4xl mx-auto px-4 py-4">
+          <div className="flex items-center gap-2">
+            <Crown size={24} className="text-[var(--color-accent)]" />
+            <h1 className="text-lg font-medium tracking-wide">物欲王</h1>
           </div>
         </div>
       </header>
@@ -244,38 +244,38 @@ export default function SettingsPage() {
       <main className="max-w-4xl mx-auto px-4 py-6">
         <Link 
           href="/" 
-          className="inline-flex items-center gap-2 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:text-gray-100 mb-6"
+          className="inline-flex items-center gap-2 text-[var(--color-muted)] hover:text-[var(--color-text)] mb-6"
         >
           <ArrowLeft size={18} />
           戻る
         </Link>
 
-        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-6">設定</h2>
+        <h2 className="text-xl font-bold text-[var(--color-text)] mb-6">設定</h2>
 
         <div className="space-y-4">
           {/* アカウント情報 (折りたたみなし) */}
-          <div className="bg-white dark:bg-slate-800 rounded-lg shadow p-6">
-            <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-4">アカウント情報</h3>
+          <div className="bg-[var(--color-card)] rounded-lg shadow p-6">
+            <h3 className="font-semibold text-[var(--color-text)] mb-4">アカウント情報</h3>
             <div className="space-y-2 text-sm">
               <div className="flex">
                 <span className="text-gray-500 dark:text-gray-400 dark:text-gray-500 w-32">メール:</span>
-                <span className="text-gray-900 dark:text-gray-100">{user.email}</span>
+                <span className="text-[var(--color-text)]">{user.email}</span>
               </div>
               {user.name && (
                 <div className="flex">
                   <span className="text-gray-500 dark:text-gray-400 dark:text-gray-500 w-32">名前:</span>
-                  <span className="text-gray-900 dark:text-gray-100">{user.name}</span>
+                  <span className="text-[var(--color-text)]">{user.name}</span>
                 </div>
               )}
             </div>
           </div>
 
           {/* カテゴリ管理 */}
-          <div className="bg-white dark:bg-slate-800 rounded-lg shadow">
+          <div className="bg-[var(--color-card)] rounded-lg shadow">
             <button onClick={() => toggleSection('categories')} className="w-full p-4 flex items-center justify-between hover:bg-gray-50 dark:bg-slate-700 dark:hover:bg-slate-700 rounded-lg">
               <div className="flex items-center gap-2">
-                <Tag size={20} className="text-orange-500" />
-                <h3 className="font-semibold text-gray-900 dark:text-gray-100">カテゴリ管理</h3>
+                <Tag size={20} className="text-[var(--color-primary)]" />
+                <h3 className="font-semibold text-[var(--color-text)]">カテゴリ管理</h3>
                 <span className="text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">({categories.length})</span>
               </div>
               {openSections.categories ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
@@ -296,7 +296,7 @@ export default function SettingsPage() {
                             <input type="color" value={editCategoryColor} onChange={(e) => setEditCategoryColor(e.target.value)} className="w-8 h-8 rounded cursor-pointer" />
                             <input type="text" value={editCategoryName} onChange={(e) => setEditCategoryName(e.target.value)} className="flex-1 px-2 py-1 border rounded text-sm" autoFocus />
                             <button onClick={handleUpdateCategory} className="text-green-500 hover:text-green-600"><Check size={18} /></button>
-                            <button onClick={() => setEditingCategoryId(null)} className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:text-gray-300"><X size={18} /></button>
+                            <button onClick={() => setEditingCategoryId(null)} className="text-gray-400 dark:text-gray-500 hover:text-[var(--color-muted)]"><X size={18} /></button>
                           </>
                         ) : (
                           <>
@@ -315,11 +315,11 @@ export default function SettingsPage() {
           </div>
 
           {/* 比較グループ管理 */}
-          <div className="bg-white dark:bg-slate-800 rounded-lg shadow">
+          <div className="bg-[var(--color-card)] rounded-lg shadow">
             <button onClick={() => toggleSection('groups')} className="w-full p-4 flex items-center justify-between hover:bg-gray-50 dark:bg-slate-700 dark:hover:bg-slate-700 rounded-lg">
               <div className="flex items-center gap-2">
-                <Layers size={20} className="text-orange-500" />
-                <h3 className="font-semibold text-gray-900 dark:text-gray-100">比較グループ管理</h3>
+                <Layers size={20} className="text-[var(--color-primary)]" />
+                <h3 className="font-semibold text-[var(--color-text)]">比較グループ管理</h3>
                 <span className="text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">({groups.length})</span>
               </div>
               {openSections.groups ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
@@ -338,11 +338,11 @@ export default function SettingsPage() {
                           <>
                             <input type="text" value={editGroupName} onChange={(e) => setEditGroupName(e.target.value)} className="flex-1 px-2 py-1 border rounded text-sm" autoFocus />
                             <button onClick={handleUpdateGroup} className="text-green-500 hover:text-green-600"><Check size={18} /></button>
-                            <button onClick={() => setEditingGroupId(null)} className="text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:text-gray-300"><X size={18} /></button>
+                            <button onClick={() => setEditingGroupId(null)} className="text-gray-400 dark:text-gray-500 hover:text-[var(--color-muted)]"><X size={18} /></button>
                           </>
                         ) : (
                           <>
-                            <Layers size={16} className="text-orange-500" />
+                            <Layers size={16} className="text-[var(--color-primary)]" />
                             <span className="flex-1 text-sm">{group.name}</span>
                             <button onClick={() => { setEditingGroupId(group.id); setEditGroupName(group.name); }} className="text-gray-400 dark:text-gray-500 hover:text-blue-500"><Pencil size={16} /></button>
                             <button onClick={() => handleDeleteGroup(group.id)} className="text-gray-400 dark:text-gray-500 hover:text-red-500"><X size={18} /></button>
@@ -358,11 +358,11 @@ export default function SettingsPage() {
           </div>
 
           {/* ゴミ箱 */}
-          <div className="bg-white dark:bg-slate-800 rounded-lg shadow">
+          <div className="bg-[var(--color-card)] rounded-lg shadow">
             <button onClick={() => toggleSection('trash')} className="w-full p-4 flex items-center justify-between hover:bg-gray-50 dark:bg-slate-700 dark:hover:bg-slate-700 rounded-lg">
               <div className="flex items-center gap-2">
-                <Trash2 size={20} className="text-orange-500" />
-                <h3 className="font-semibold text-gray-900 dark:text-gray-100">ゴミ箱</h3>
+                <Trash2 size={20} className="text-[var(--color-primary)]" />
+                <h3 className="font-semibold text-[var(--color-text)]">ゴミ箱</h3>
                 <span className="text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">({trashItems.length}件)</span>
               </div>
               {openSections.trash ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
@@ -391,61 +391,100 @@ export default function SettingsPage() {
           </div>
 
           {/* テーマ設定 */}
-          <div className="bg-white dark:bg-slate-800 rounded-lg shadow">
-            <button onClick={() => toggleSection('theme')} className="w-full p-4 flex items-center justify-between hover:bg-gray-50 dark:hover:bg-slate-700 rounded-lg">
+          <div className="bg-[var(--color-card)] rounded-lg shadow">
+            <button onClick={() => toggleSection('theme')} className="w-full p-4 flex items-center justify-between hover:bg-[var(--color-border)] rounded-lg">
               <div className="flex items-center gap-2">
-                <Sun size={20} className="text-orange-500" />
-                <h3 className="font-semibold text-gray-900 dark:text-gray-100">テーマ</h3>
+                <Sun size={20} className="text-[var(--color-primary)]" />
+                <h3 className="font-semibold text-[var(--color-text)]">テーマ</h3>
               </div>
-              {openSections.theme ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
+              {openSections.theme ? <ChevronUp size={20} className="text-[var(--color-muted)]" /> : <ChevronDown size={20} className="text-[var(--color-muted)]" />}
             </button>
             {openSections.theme && (
-              <div className="px-4 pb-4 border-t dark:border-slate-700">
-                <div className="flex gap-2 pt-4">
-                  <button
-                    onClick={() => setTheme('light')}
-                    className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
-                      theme === 'light'
-                        ? 'bg-orange-500 text-white'
-                        : 'bg-gray-100 dark:bg-slate-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-slate-600'
-                    }`}
-                  >
-                    <Sun size={16} />
-                    ライト
-                  </button>
-                  <button
-                    onClick={() => setTheme('dark')}
-                    className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
-                      theme === 'dark'
-                        ? 'bg-orange-500 text-white'
-                        : 'bg-gray-100 dark:bg-slate-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-slate-600'
-                    }`}
-                  >
-                    <Moon size={16} />
-                    ダーク
-                  </button>
-                  <button
-                    onClick={() => setTheme('system')}
-                    className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
-                      theme === 'system'
-                        ? 'bg-orange-500 text-white'
-                        : 'bg-gray-100 dark:bg-slate-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-slate-600'
-                    }`}
-                  >
-                    <Monitor size={16} />
-                    自動
-                  </button>
+              <div className="px-4 pb-4 border-t border-[var(--color-border)]">
+                {/* カラースキーム */}
+                <div className="pt-4">
+                  <div className="flex items-center gap-2 mb-2">
+                    <Palette size={16} className="text-[var(--color-muted)]" />
+                    <span className="text-sm font-medium text-[var(--color-text)]">カラースキーム</span>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => setColorScheme('wa-modern')}
+                      className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
+                        colorScheme === 'wa-modern'
+                          ? 'bg-[var(--color-primary)] text-white'
+                          : 'bg-[var(--color-border)] text-[var(--color-muted)] hover:bg-[var(--color-muted-light)] hover:text-white'
+                      }`}
+                    >
+                      <span className="w-4 h-4 rounded-full bg-[#c53d43]"></span>
+                      和モダン
+                    </button>
+                    <button
+                      onClick={() => setColorScheme('default')}
+                      className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
+                        colorScheme === 'default'
+                          ? 'bg-[var(--color-primary)] text-white'
+                          : 'bg-[var(--color-border)] text-[var(--color-muted)] hover:bg-[var(--color-muted-light)] hover:text-white'
+                      }`}
+                    >
+                      <span className="w-4 h-4 rounded-full bg-[#f97316]"></span>
+                      デフォルト
+                    </button>
+                  </div>
+                </div>
+                
+                {/* 明るさ */}
+                <div className="pt-4">
+                  <div className="flex items-center gap-2 mb-2">
+                    <Sun size={16} className="text-[var(--color-muted)]" />
+                    <span className="text-sm font-medium text-[var(--color-text)]">明るさ</span>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => setTheme('light')}
+                      className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
+                        theme === 'light'
+                          ? 'bg-[var(--color-primary)] text-white'
+                          : 'bg-[var(--color-border)] text-[var(--color-muted)] hover:bg-[var(--color-muted-light)] hover:text-white'
+                      }`}
+                    >
+                      <Sun size={16} />
+                      ライト
+                    </button>
+                    <button
+                      onClick={() => setTheme('dark')}
+                      className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
+                        theme === 'dark'
+                          ? 'bg-[var(--color-primary)] text-white'
+                          : 'bg-[var(--color-border)] text-[var(--color-muted)] hover:bg-[var(--color-muted-light)] hover:text-white'
+                      }`}
+                    >
+                      <Moon size={16} />
+                      ダーク
+                    </button>
+                    <button
+                      onClick={() => setTheme('system')}
+                      className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${
+                        theme === 'system'
+                          ? 'bg-[var(--color-primary)] text-white'
+                          : 'bg-[var(--color-border)] text-[var(--color-muted)] hover:bg-[var(--color-muted-light)] hover:text-white'
+                      }`}
+                    >
+                      <Monitor size={16} />
+                      自動
+                    </button>
+                  </div>
                 </div>
               </div>
             )}
           </div>
 
           {/* 価格通知設定 */}
-          <div className="bg-white dark:bg-slate-800 rounded-lg shadow">
+          <div className="bg-[var(--color-card)] rounded-lg shadow">
             <button onClick={() => toggleSection('notify')} className="w-full p-4 flex items-center justify-between hover:bg-gray-50 dark:bg-slate-700 dark:hover:bg-slate-700 rounded-lg">
               <div className="flex items-center gap-2">
-                <Bell size={20} className="text-orange-500" />
-                <h3 className="font-semibold text-gray-900 dark:text-gray-100">価格通知設定</h3>
+                <Bell size={20} className="text-[var(--color-primary)]" />
+                <h3 className="font-semibold text-[var(--color-text)]">価格通知設定</h3>
               </div>
               {openSections.notify ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
             </button>
@@ -460,10 +499,10 @@ export default function SettingsPage() {
                   <input type="url" value={notifySettings.discord_webhook} onChange={(e) => setNotifySettings({ ...notifySettings, discord_webhook: e.target.value })} placeholder="https://discord.com/api/webhooks/..." className="w-full px-3 py-2 border border-gray-300 dark:border-slate-600 rounded-md text-sm" />
                 </div>
                 <div className="space-y-2">
-                  <label className="flex items-center gap-2"><input type="checkbox" checked={notifySettings.notify_on_price_drop} onChange={(e) => setNotifySettings({ ...notifySettings, notify_on_price_drop: e.target.checked })} className="rounded border-gray-300 dark:border-slate-600 text-orange-500" /><span className="text-sm text-gray-700">価格が下がったら通知</span></label>
-                  <label className="flex items-center gap-2"><input type="checkbox" checked={notifySettings.notify_on_target_price} onChange={(e) => setNotifySettings({ ...notifySettings, notify_on_target_price: e.target.checked })} className="rounded border-gray-300 dark:border-slate-600 text-orange-500" /><span className="text-sm text-gray-700">目標価格に達したら通知</span></label>
+                  <label className="flex items-center gap-2"><input type="checkbox" checked={notifySettings.notify_on_price_drop} onChange={(e) => setNotifySettings({ ...notifySettings, notify_on_price_drop: e.target.checked })} className="rounded border-gray-300 dark:border-slate-600 text-[var(--color-primary)]" /><span className="text-sm text-gray-700">価格が下がったら通知</span></label>
+                  <label className="flex items-center gap-2"><input type="checkbox" checked={notifySettings.notify_on_target_price} onChange={(e) => setNotifySettings({ ...notifySettings, notify_on_target_price: e.target.checked })} className="rounded border-gray-300 dark:border-slate-600 text-[var(--color-primary)]" /><span className="text-sm text-gray-700">目標価格に達したら通知</span></label>
                 </div>
-                <button onClick={saveNotifySettings} disabled={savingNotify} className="px-4 py-2 bg-orange-500 text-white rounded-md hover:bg-orange-600 disabled:opacity-50 flex items-center gap-2">
+                <button onClick={saveNotifySettings} disabled={savingNotify} className="px-4 py-2 bg-[var(--color-primary)] text-white rounded-md hover:bg-[var(--color-primary-hover)] disabled:opacity-50 flex items-center gap-2">
                   {savingNotify ? <><Loader2 size={18} className="animate-spin" /> 保存中...</> : notifySaved ? <><Check size={18} /> 保存しました</> : '保存'}
                 </button>
               </div>
@@ -471,17 +510,17 @@ export default function SettingsPage() {
           </div>
 
           {/* Chrome拡張機能用トークン */}
-          <div className="bg-white dark:bg-slate-800 rounded-lg shadow">
+          <div className="bg-[var(--color-card)] rounded-lg shadow">
             <button onClick={() => toggleSection('token')} className="w-full p-4 flex items-center justify-between hover:bg-gray-50 dark:bg-slate-700 dark:hover:bg-slate-700 rounded-lg">
               <div className="flex items-center gap-2">
-                <Key size={20} className="text-orange-500" />
-                <h3 className="font-semibold text-gray-900 dark:text-gray-100">Chrome拡張機能用トークン</h3>
+                <Key size={20} className="text-[var(--color-primary)]" />
+                <h3 className="font-semibold text-[var(--color-text)]">Chrome拡張機能用トークン</h3>
               </div>
               {openSections.token ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
             </button>
             {openSections.token && (
               <div className="px-4 pb-4 border-t pt-4">
-                <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">Chrome拡張機能でほしいものリストをインポートする際に必要です。</p>
+                <p className="text-sm text-[var(--color-muted)] mb-4">Chrome拡張機能でほしいものリストをインポートする際に必要です。</p>
                 {displayToken ? (
                   <div className="flex gap-2">
                     <input type="text" value={displayToken} readOnly className="flex-1 px-3 py-2 border border-gray-300 dark:border-slate-600 rounded-md bg-gray-50 dark:bg-slate-700 text-sm font-mono" />
@@ -496,17 +535,17 @@ export default function SettingsPage() {
           </div>
 
           {/* データエクスポート */}
-          <div className="bg-white dark:bg-slate-800 rounded-lg shadow">
+          <div className="bg-[var(--color-card)] rounded-lg shadow">
             <button onClick={() => toggleSection('export')} className="w-full p-4 flex items-center justify-between hover:bg-gray-50 dark:bg-slate-700 dark:hover:bg-slate-700 rounded-lg">
               <div className="flex items-center gap-2">
-                <Download size={20} className="text-orange-500" />
-                <h3 className="font-semibold text-gray-900 dark:text-gray-100">データエクスポート</h3>
+                <Download size={20} className="text-[var(--color-primary)]" />
+                <h3 className="font-semibold text-[var(--color-text)]">データエクスポート</h3>
               </div>
               {openSections.export ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
             </button>
             {openSections.export && (
               <div className="px-4 pb-4 border-t pt-4">
-                <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">データをCSV形式でダウンロードできます。</p>
+                <p className="text-sm text-[var(--color-muted)] mb-4">データをCSV形式でダウンロードできます。</p>
                 <div className="flex flex-wrap gap-3">
                   <a href="/api/export?filter=wishlist" className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 flex items-center gap-2"><Download size={18} />ほしいものリスト</a>
                   <a href="/api/export?filter=purchased" className="px-4 py-2 bg-green-500 text-white rounded-md hover:bg-green-600 flex items-center gap-2"><Download size={18} />購入済み</a>

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -3,11 +3,14 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 
 type Theme = 'light' | 'dark' | 'system';
+type ColorScheme = 'default' | 'wa-modern';
 
 interface ThemeContextType {
   theme: Theme;
   setTheme: (theme: Theme) => void;
   resolvedTheme: 'light' | 'dark';
+  colorScheme: ColorScheme;
+  setColorScheme: (scheme: ColorScheme) => void;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
@@ -15,13 +18,18 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setThemeState] = useState<Theme>('system');
   const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('light');
+  const [colorScheme, setColorSchemeState] = useState<ColorScheme>('wa-modern');
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
-    const stored = localStorage.getItem('theme') as Theme | null;
-    if (stored) {
-      setThemeState(stored);
+    const storedTheme = localStorage.getItem('theme') as Theme | null;
+    const storedColorScheme = localStorage.getItem('colorScheme') as ColorScheme | null;
+    if (storedTheme) {
+      setThemeState(storedTheme);
+    }
+    if (storedColorScheme) {
+      setColorSchemeState(storedColorScheme);
     }
   }, []);
 
@@ -52,9 +60,28 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     }
   }, [theme, mounted]);
 
+  // カラースキームの適用
+  useEffect(() => {
+    if (!mounted) return;
+    
+    const root = document.documentElement;
+    if (colorScheme === 'wa-modern') {
+      root.classList.add('wa-modern');
+      root.classList.remove('default-scheme');
+    } else {
+      root.classList.add('default-scheme');
+      root.classList.remove('wa-modern');
+    }
+  }, [colorScheme, mounted]);
+
   const setTheme = (newTheme: Theme) => {
     setThemeState(newTheme);
     localStorage.setItem('theme', newTheme);
+  };
+
+  const setColorScheme = (newScheme: ColorScheme) => {
+    setColorSchemeState(newScheme);
+    localStorage.setItem('colorScheme', newScheme);
   };
 
   // ハイドレーション対策：マウント前は何もレンダリングしない
@@ -63,7 +90,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <ThemeContext.Provider value={{ theme, setTheme, resolvedTheme }}>
+    <ThemeContext.Provider value={{ theme, setTheme, resolvedTheme, colorScheme, setColorScheme }}>
       {children}
     </ThemeContext.Provider>
   );
@@ -77,6 +104,8 @@ export function useTheme() {
       theme: 'system' as const,
       setTheme: () => {},
       resolvedTheme: 'light' as const,
+      colorScheme: 'wa-modern' as const,
+      setColorScheme: () => {},
     };
   }
   return context;


### PR DESCRIPTION
## 概要

Issue #4 を実装。設定ページでカラースキームを切り替えられるようになりました。

## 変更内容

### ThemeProvider
- `colorScheme` 状態を追加（'wa-modern' | 'default'）
- localStorage に保存して永続化

### 設定ページ
- テーマセクションに「カラースキーム」選択を追加
- デザインを和モダン対応に統一（CSS変数を使用）

### CSS
- 共通のCSS変数を定義（`--color-primary`, `--color-bg` など）
- `.default-scheme` クラスでデフォルトスキームの値をオーバーライド

## スクリーンショット

- 和モダン: 朱色のアクセント、藍色のヘッダー、生成り色の背景
- デフォルト: オレンジのアクセント、青色のヘッダー、グレーの背景

Closes #4