### PR TITLE
デフォルトスキームのヘッダー色（--ai変数）をオレンジに修正

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -102,7 +102,7 @@
   --shiro: #ffffff;
   --shu: #f97316;
   --shu-light: #ea580c;
-  --ai: #3b82f6;
+  --ai: #f97316;  /* デフォルトはオレンジ */
   --matcha: #166534;
   --kitsune: #fbbf24;
   --sakura: #fee2e2;


### PR DESCRIPTION
メインページのヘッダーは`--ai`変数を使用しているため、デフォルトスキームでこの変数もオレンジにオーバーライドする必要があった