### PR TITLE
fix: Shopifyサイトの価格スクレイピングを修正

### DIFF
--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -277,10 +277,10 @@ async function scrapeGeneric(sanitizedUrl: string, hostname: string): Promise<Sc
     }
     
     if (!price) {
-      // "price":NNNNNNN (セント単位) + JPY通貨がページ内にある場合
-      const hasJPY = html.includes('"priceCurrency":"JPY"') || html.includes("'priceCurrency':'JPY'");
-      if (hasJPY) {
-        // Shopifyの場合、"price":NNNNNN (5桁以上、セント単位) があればJPY
+      // Shopifyサイトのセント単位価格（Shopifyかどうかを確認）
+      const isShopify = html.includes('cdn.shopify.com') || html.includes('Shopify.theme');
+      if (isShopify) {
+        // Shopifyの場合、"price":NNNNNN (5桁以上、セント単位) をJPYとみなす
         const shopifyPriceMatch = html.match(/"price":(\d{5,})/);
         if (shopifyPriceMatch) {
           // 100で割って円に変換


### PR DESCRIPTION
## 概要
Shopifyサイト（nomanzgear.comなど）の価格が正しく取得できない問題を修正しました。

## 原因
1. サーバーからfetchすると、ジオロケーションによりUSD価格が返されていた
2. JSON-LDの`hasVariant`配列内の価格を見ていなかった

## 修正内容
- `localization=JP; cart_currency=JPY` クッキーを送信して日本円価格を取得
- JSON-LDパーサーを改善:
  - `hasVariant`配列内の`offers.price`をチェック
  - `priceCurrency: JPY`を優先的に取得
- フォールバックパターンの追加

## テスト結果
```
https://nomanzgear.com/products/dirac → ¥65,900 ✓
https://nomanzgear.com/products/kepler → ¥9,900 ✓
```

Closes #9