### PR TITLE
fix: 販売価格パターンをより厳密に

### DIFF
--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -504,12 +504,12 @@ async function scrapeGeneric(sanitizedUrl: string, hostname: string): Promise<Sc
     }
 
     if (!price) {
-      // 「販売価格」や「税込」の近くにある価格を探す
-      const salePriceMatch = html.match(/販売価格[^\d]*([\d,]+)/) ||
-                             html.match(/税込[^\d]*([\d,]+)/);
+      // 「販売価格」の近くにある価格を探す（より厳密なパターン）
+      // 「販売価格: 1,234円」や「販売価格：¥1,234」のような形式
+      const salePriceMatch = html.match(/販売価格[\s：:]*¥?\s*([\d,]+)/);
       if (salePriceMatch) {
         const extracted = parseInt(salePriceMatch[1].replace(/,/g, ''), 10);
-        if (extracted > 0) {
+        if (extracted >= 100) { // 100円未満は除外
           price = extracted;
         }
       }


### PR DESCRIPTION
## 問題
- https://www.ecshop.undiscovered.jp/product-page/reiwa-enjiro-legend-set → ¥3（本来は¥8,670）
- https://shop.wittamer.jp/category/W_CT202/1-CF-18W.html → ¥201（本来は¥1,944）

### 原因
`税込[^\d]*([\d,]+)` パターンが「税込）」の後の無関係な数字にマッチしていた

## 修正内容
- 「税込」パターンを削除（誤検出が多い）
- 「販売価格」パターンをより厳密に：`販売価格[\s：:]*¥?\s*([\d,]+)`
- 100円未満は除外（明らかに誤検出）

## テスト結果
| サイト | 修正前 | 修正後 |
|--------|--------|--------|
| ecshop.undiscovered.jp | ¥3 | ¥8,670 ✅ |
| shop.wittamer.jp | ¥201 | ¥1,944 ✅ |
| gsakai.co.jp | ¥16,280 | ¥16,280 ✅ |
| bambulab.com | ¥29,800 | ¥29,800 ✅ |