### PR TITLE
fix: DBマイグレーション機構を追加し quantity/sort_order カラムをスキーマに反映 (#32)

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -45,6 +45,8 @@ function initDb(db: Database.Database) {
       purchased_at TEXT,
       target_price INTEGER,
       target_currency TEXT DEFAULT 'JPY',
+      quantity INTEGER NOT NULL DEFAULT 1,
+      sort_order INTEGER NOT NULL DEFAULT 0,
       deleted_at TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       updated_at TEXT NOT NULL DEFAULT (datetime('now')),
@@ -111,4 +113,28 @@ function initDb(db: Database.Database) {
     CREATE INDEX IF NOT EXISTS idx_comparison_groups_user ON comparison_groups(user_id);
     CREATE INDEX IF NOT EXISTS idx_categories_user ON categories(user_id);
   `);
+
+  migrateDb(db);
+}
+
+// 既存DBへのスキーマ変更を反映する簡易マイグレーション
+// CREATE TABLE IF NOT EXISTS は既存テーブルを変更しないため、
+// 後から追加されたカラムはここで ALTER TABLE により追従させる
+function migrateDb(db: Database.Database) {
+  addColumnIfNotExists(db, 'items', 'quantity', 'INTEGER NOT NULL DEFAULT 1');
+  addColumnIfNotExists(db, 'items', 'sort_order', 'INTEGER NOT NULL DEFAULT 0');
+}
+
+// テーブルに指定カラムが存在しない場合のみ ALTER TABLE で追加する
+// table / column / definition はコード内で定義した定数のみを渡すこと（ユーザー入力は不可）
+function addColumnIfNotExists(
+  db: Database.Database,
+  table: string,
+  column: string,
+  definition: string
+) {
+  const columns = db.pragma(`table_info(${table})`) as { name: string }[];
+  if (!columns.some((c) => c.name === column)) {
+    db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+  }
 }


### PR DESCRIPTION
## 変更概要

`src/lib/db.ts` の `items` テーブル定義に `quantity` / `sort_order` カラムが存在せず、コード（`src/app/api/items/route.ts` の GET/POST）がこれらを参照しているため、新規環境では SQLite エラーが発生していた。

- `CREATE TABLE items` 定義に `quantity INTEGER NOT NULL DEFAULT 1` と `sort_order INTEGER NOT NULL DEFAULT 0` を正式に反映（新規DBは CREATE TABLE で完結）
- 簡易マイグレーション機構を追加
  - `migrateDb()`: 既存DBへのスキーマ変更を集約する関数。`initDb()` から呼び出す
  - `addColumnIfNotExists()`: `PRAGMA table_info` で既存カラムを確認し、不足分のみ `ALTER TABLE ... ADD COLUMN` で追加する汎用ヘルパー。今後のスキーマ変更にも使い回せる

## 動作確認

worktree 内で一時検証スクリプト（コミットには未含有）を `npx tsx` で実行して確認:

1. **新規DB**（`data/` 空の状態で `getDb()`）: `PRAGMA table_info(items)` に `quantity` / `sort_order` が含まれることを確認
2. **旧スキーマDB**（quantity/sort_order なしの旧 CREATE TABLE 定義 + 既存行1件を用意して `getDb()`）: 両カラムが ALTER で追加され、既存行に `quantity=1` / `sort_order=0` のデフォルト値が入ることを確認
3. **マイグレーション済みDB**で再度 `getDb()`: エラーなく起動（冪等性）を確認
4. `npx tsc --noEmit`: 型エラーなし

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)