### PR TITLE
fix: scraperにHTTPステータス確認と指数バックオフリトライを追加 (#13)

### DIFF
--- a/scripts/check-prices.ts
+++ b/scripts/check-prices.ts
@@ -109,11 +109,11 @@ async function checkPrices() {
         }
       }
 
-      // レートリミット対策で20.5秒待機
-      await new Promise(resolve => setTimeout(resolve, 500));
-
     } catch (error) {
       console.error(`  - Error: ${error}`);
+    } finally {
+      // レートリミット対策で5秒待機（スキップ・エラー時も含め全アイテム間に適用）
+      await new Promise(resolve => setTimeout(resolve, 5000));
     }
   }
 

--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -34,6 +34,67 @@ const RAKUTEN_DOMAINS = new Set([
   'product.rakuten.co.jp',
 ]);
 
+export interface FetchWithRetryOptions {
+  maxRetries?: number; // 最大リトライ回数（デフォルト: 3）
+  baseDelayMs?: number; // リトライ間隔の基準ミリ秒（デフォルト: 1000）
+}
+
+// リトライ間隔の倍率（baseDelayMs=1000の場合: 1秒 → 5秒 → 15秒）
+const RETRY_DELAY_MULTIPLIERS = [1, 5, 15];
+
+/**
+ * HTTPステータス確認と指数バックオフリトライ付きのfetch
+ * - 429 / 5xx 応答とネットワークエラー時に最大maxRetries回リトライする
+ * - 404等の4xx（429除く）はリトライせず即座にエラーを投げる
+ * - リトライが尽きた場合は最後のエラーを投げる
+ */
+export async function fetchWithRetry(
+  url: string,
+  init?: RequestInit,
+  options?: FetchWithRetryOptions
+): Promise<Response> {
+  const maxRetries = options?.maxRetries ?? 3;
+  const baseDelayMs = options?.baseDelayMs ?? 1000;
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    let response: Response | null = null;
+    try {
+      response = await fetch(url, init);
+    } catch (error) {
+      // ネットワークエラーはリトライ対象
+      lastError = error instanceof Error ? error : new Error(String(error));
+    }
+
+    if (response) {
+      if (response.ok) {
+        return response;
+      }
+
+      // 429（レート制限）と5xx（サーバーエラー）のみリトライ対象
+      const isRetryable = response.status === 429 || response.status >= 500;
+      if (!isRetryable) {
+        // 404等の4xx（429除く）はリトライせず即座に失敗
+        throw new Error(`HTTP error ${response.status}: ${url}`);
+      }
+      lastError = new Error(`HTTP error ${response.status}: ${url}`);
+    }
+
+    // リトライ回数が残っていれば指数バックオフで待機
+    if (attempt < maxRetries) {
+      const multiplier =
+        RETRY_DELAY_MULTIPLIERS[Math.min(attempt, RETRY_DELAY_MULTIPLIERS.length - 1)];
+      const delayMs = baseDelayMs * multiplier;
+      console.log(
+        `Fetch failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delayMs}ms: ${url}`
+      );
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+
+  throw lastError ?? new Error(`Fetch failed after ${maxRetries + 1} attempts: ${url}`);
+}
+
 /**
  * URLのホスト名を取得（SSRF対策のガード）
  */
@@ -116,7 +177,7 @@ async function expandShortUrl(url: string): Promise<string | null> {
   try {
     // redirect: 'follow'で自動的にリダイレクトを追跡し、最終URLを取得
     // safeUrlはホワイトリストから構築された安全なURL
-    const response = await fetch(safeUrl, {
+    const response = await fetchWithRetry(safeUrl, {
       method: 'GET',
       redirect: 'follow',
       headers: {
@@ -225,7 +286,7 @@ async function scrapeAmazon(sanitizedUrl: string): Promise<ScrapedItem> {
   }
 
   try {
-    const response = await fetch(sanitizedUrl, {
+    const response = await fetchWithRetry(sanitizedUrl, {
       headers: {
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
         'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
@@ -311,7 +372,7 @@ async function scrapeRakuten(sanitizedUrl: string): Promise<ScrapedItem> {
   }
 
   try {
-    const response = await fetch(sanitizedUrl, {
+    const response = await fetchWithRetry(sanitizedUrl, {
       headers: {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
         'Accept-Language': 'ja-JP,ja;q=0.9,en;q=0.8',
@@ -371,7 +432,7 @@ async function scrapeGeneric(sanitizedUrl: string, hostname: string): Promise<Sc
   }
 
   try {
-    const response = await fetch(sanitizedUrl, {
+    const response = await fetchWithRetry(sanitizedUrl, {
       headers: {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
         'Accept-Language': 'ja-JP,ja;q=0.9,en;q=0.8',


### PR DESCRIPTION
## 変更概要

定期スクレイピングでAmazon価格が取得できない問題（#13）への対応として、HTTPステータス確認とリトライ機構を追加した。

### src/lib/scraper.ts
- エクスポートされた `fetchWithRetry(url, init?, options?)` ヘルパーを追加
  - `options` で `maxRetries`（デフォルト3）と `baseDelayMs`（デフォルト1000）を上書き可能
  - `response.ok` を確認し、**429 / 5xx** とネットワークエラー時に指数バックオフ（1秒 → 5秒 → 15秒）で最大3回リトライ
  - 404等の4xx（429除く）はリトライせず即座にエラーを投げる
  - リトライが尽きた場合は最後のエラーを投げる（既存の try/catch によるフォールバック処理で捕捉される）
- 既存のfetch呼び出し4箇所（Amazon・楽天・汎用サイト・短縮URL展開）を `fetchWithRetry` 経由に置き換え
- 価格抽出ロジックと戻り値の形は変更なし

### scripts/check-prices.ts
- アイテム間ディレイを 500ms → **5000ms** に延長
- 価格未取得時の `continue` やエラー時に待機がスキップされていたため、`finally` に移動して全アイテム間で確実に待機するよう修正

## 動作確認

ローカルHTTPサーバ（Node http モジュール）に対して `baseDelayMs: 10` で検証（確認用スクリプトはコミットに含めていない）:

- 2回503を返してから200を返すエンドポイント → リトライ後に成功（計3リクエスト）: PASS
- 2回429を返してから200を返すエンドポイント → リトライ後に成功（計3リクエスト）: PASS
- 常に503を返すエンドポイント → 初回+3リトライ=計4リクエスト後に失敗: PASS
- 404を返すエンドポイント → リトライせず1リクエストで即失敗: PASS
- `maxRetries: 1` 上書き → 計2リクエストで失敗: PASS
- バックオフ間隔が 1x → 5x → 15x（デフォルトで 1秒 → 5秒 → 15秒）であることをログで確認
- `npx tsc --noEmit` で型エラーなし

Refs #13（Puppeteerフォールバック実装まで Issue は残すため Closes にしない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)