### PR TITLE
perf: 初期データ取得を並列化 (#34)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -61,9 +61,8 @@ export default function Home() {
 
   useEffect(() => {
     if (user) {
-      fetchItems();
-      fetchGroups();
-      fetchCategories();
+      // 初期データを並列で取得する（1つが失敗しても他の結果は反映される）
+      Promise.allSettled([fetchItems(), fetchGroups(), fetchCategories()]);
     }
   }, [user]);
 


### PR DESCRIPTION
## 変更概要

`src/app/page.tsx` の初期データ取得（`fetchItems` / `fetchGroups` / `fetchCategories`）を `Promise.allSettled` で明示的に並列実行するように変更しました。

- 認証完了後の useEffect 内で 3 つの fetch を `Promise.allSettled` でまとめて実行
- `allSettled` を使用しているため、1 つの fetch が失敗しても他の結果は反映される（既存の挙動を維持）
- UI・表示内容の変更はなし。各 fetch 関数自体（エラーハンドリング含む）は無変更
- リフレッシュ等の他の呼び出し箇所は本タスクのスコープ外のため変更なし

## 動作確認

- `npx tsc --noEmit`: エラーなし
- `npm run build`: 成功
- `npm run dev` でアプリを起動し、トップページが HTTP 200 で表示されることを確認（認証前画面まで）

Refs #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)