### PR TITLE
perf: /api/items の相関サブクエリを解消し複合インデックスを追加 (#35)

### DIFF
--- a/src/app/api/items/route.ts
+++ b/src/app/api/items/route.ts
@@ -10,24 +10,29 @@ export async function GET() {
   }
 
   const db = getDb();
+  // previous_price は行ごとの相関サブクエリではなく、ウィンドウ関数で
+  // 各アイテムの「2番目に新しい価格履歴」を一括導出して LEFT JOIN する。
+  // ORDER BY の id DESC は recorded_at 同値時の結果を決定的にするため。
   const items = db.prepare(`
-    SELECT 
+    SELECT
       i.*,
       cg.name as comparison_group_name,
       cg.priority as group_priority,
       cat.name as category_name,
       cat.color as category_color,
-      (
-        SELECT price FROM price_history 
-        WHERE item_id = i.id 
-        ORDER BY recorded_at DESC 
-        LIMIT 1 OFFSET 1
-      ) as previous_price
+      prev.price as previous_price
     FROM items i
     LEFT JOIN comparison_groups cg ON i.comparison_group_id = cg.id
     LEFT JOIN categories cat ON i.category_id = cat.id
+    LEFT JOIN (
+      SELECT item_id, price FROM (
+        SELECT item_id, price,
+               ROW_NUMBER() OVER (PARTITION BY item_id ORDER BY recorded_at DESC, id DESC) AS rn
+        FROM price_history
+      ) WHERE rn = 2
+    ) prev ON prev.item_id = i.id
     WHERE i.is_purchased = 0 AND i.user_id = ? AND i.deleted_at IS NULL
-    ORDER BY 
+    ORDER BY
       COALESCE(cg.priority, i.priority) ASC,
       i.sort_order ASC,
       i.created_at DESC

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -110,5 +110,8 @@ function initDb(db: Database.Database) {
     CREATE INDEX IF NOT EXISTS idx_price_history_item ON price_history(item_id, recorded_at);
     CREATE INDEX IF NOT EXISTS idx_comparison_groups_user ON comparison_groups(user_id);
     CREATE INDEX IF NOT EXISTS idx_categories_user ON categories(user_id);
+    CREATE INDEX IF NOT EXISTS idx_items_user_status ON items(user_id, is_purchased, deleted_at);
+    CREATE INDEX IF NOT EXISTS idx_items_user_category ON items(user_id, category_id);
+    CREATE INDEX IF NOT EXISTS idx_items_user_group ON items(user_id, comparison_group_id);
   `);
 }


### PR DESCRIPTION
## 変更概要

- `src/app/api/items/route.ts` (GET): `previous_price` の取得を行ごとの相関スカラサブクエリ（`LIMIT 1 OFFSET 1`）から、ウィンドウ関数 `ROW_NUMBER() OVER (PARTITION BY item_id ORDER BY recorded_at DESC, id DESC)` で「2番目に新しい価格履歴」を一括導出する派生テーブルへの `LEFT JOIN` に変更。price_history への行ごとのアクセス（N+1）を解消
- `src/lib/db.ts`: 既存の CREATE INDEX ブロック末尾に複合インデックスを追加（CREATE TABLE 部分は未変更）
  - `idx_items_user_status ON items(user_id, is_purchased, deleted_at)`
  - `idx_items_user_category ON items(user_id, category_id)`
  - `idx_items_user_group ON items(user_id, comparison_group_id)`

変更は `/api/items` GET のみ。他ルート（trash, purchased 等）に同パターンの相関サブクエリは存在しないことを確認済み（`LIMIT 1 OFFSET 1` は当該箇所のみ）。

## recorded_at 同値時の順序について

既存サブクエリの `ORDER BY recorded_at DESC` は同値時の順序が SQL 仕様上不定（実装上は `idx_price_history_item` の逆順スキャンにより rowid 降順）。新クエリでは `id DESC` を加えて決定的にした。検証では tie ケース（同一 recorded_at の履歴 2 件・全件同値）を含め、旧クエリと結果が完全一致した。

## 新旧クエリの結果一致確認

テストDB（origin/develop スキーマ + 本番DB相当の `quantity` / `sort_order` カラム追加）に、ユーザー 2 人・アイテム 12 件（購入済み・削除済み・グループ/カテゴリ有無を混在）、price_history 0件/1件/2件/3件以上 + recorded_at 同値ケースを投入し、旧クエリと新クエリを同一DBで実行:

```
user 1: rows old=5 new=5 -> MATCH
user 2: rows old=5 new=5 -> MATCH
RESULT: ALL MATCH（全行・全カラムの JSON 完全一致）
```

## EXPLAIN QUERY PLAN

新クエリ（要点）:

```
MATERIALIZE (subquery-1)
  SCAN price_history USING INDEX idx_price_history_item
SEARCH i USING INDEX idx_items_user_status (user_id=? AND is_purchased=? AND deleted_at=?)
SEARCH (subquery-1) USING AUTOMATIC PARTIAL COVERING INDEX (rn=? AND item_id=?) LEFT-JOIN
```

- 相関スカラサブクエリ（旧プランの `CORRELATED SCALAR SUBQUERY`）が消え、price_history は 1 回のインデックススキャンで処理
- items の絞り込みに新設の `idx_items_user_status` が使用される
- フィルタつき一覧クエリ（`user_id + category_id` / `user_id + comparison_group_id`）でも `idx_items_user_category` / `idx_items_user_group` の使用を確認

`npx tsc --noEmit` パス。

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)