### PR TITLE
fix: price-history APIに認証と所有権チェックを追加

### DIFF
--- a/src/app/api/items/[id]/price-history/route.ts
+++ b/src/app/api/items/[id]/price-history/route.ts
@@ -1,13 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/db';
+import { getCurrentUser } from '@/lib/auth';
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
+
   const { id } = await params;
   const db = getDb();
-  
+
+  // 所有権チェック: 自分のアイテムでなければ404
+  const item = db.prepare('SELECT id FROM items WHERE id = ? AND user_id = ?').get(id, user.id);
+  if (!item) {
+    return NextResponse.json({ error: 'Item not found' }, { status: 404 });
+  }
+
   const history = db.prepare(`
     SELECT * FROM price_history 
     WHERE item_id = ? 


### PR DESCRIPTION
## 脆弱性の内容

`GET /api/items/[id]/price-history`（`src/app/api/items/[id]/price-history/route.ts`）は全APIルートの中で唯一 `getCurrentUser()` を呼んでおらず、以下の問題があった。

- **未認証アクセス**: Cookie なしのリクエストでも任意の item_id の価格履歴を取得できた
- **IDOR（不適切な認可）**: item の ID は AUTOINCREMENT で列挙可能なため、他ユーザーのアイテムの価格・登録時期などのデータが漏えいし得た

## 修正内容

他の API ルート（`src/app/api/items/[id]/route.ts` 等）と同じパターンで認可を追加した。

- `getCurrentUser()` による認証チェックを追加し、未認証なら `401 {"error":"認証が必要です"}` を返す
- `items` テーブルで `id = ? AND user_id = ?` の所有権確認を行い、該当しなければ `404 {"error":"Item not found"}` を返す
- 自分のアイテムに対するレスポンス（`recorded_at ASC` ソートの履歴配列）は従来どおり変更なし
- 変更はこのルートファイル 1 ファイルのみ

唯一の利用元である `src/components/PriceChart.tsx` は Cookie 認証つきで呼び出しているため、互換性は保たれる。

## 動作確認結果（ローカル dev サーバでの curl 検証）

テストユーザー2人（userA: item 1、userB: item 2、各 price_history 2件）を作成して確認。

| ケース | リクエスト | 結果 |
| --- | --- | --- |
| (a) 未認証 | Cookie なしで `/api/items/1/price-history` | **401** `{"error":"認証が必要です"}` |
| (b) 他ユーザーのアイテム | userA の Cookie で `/api/items/2/price-history` | **404** `{"error":"Item not found"}` |
| (c) 自分のアイテム | userA の Cookie で `/api/items/1/price-history` | **200** `[{"id":1,"item_id":1,"price":1000,...},{"id":3,"item_id":1,"price":950,...}]`（recorded_at 昇順） |

`npx tsc --noEmit` パス確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)