### PR TITLE
fix: 本番環境でJWT_SECRET未設定時にフェイルファストする

### DIFF
--- a/butuyokuoh.service
+++ b/butuyokuoh.service
@@ -8,6 +8,9 @@ User=exedev
 WorkingDirectory=/home/exedev/butuyokuoh
 Environment=PORT=8000
 Environment=NODE_ENV=production
+# JWT_SECRET は本番で必須（未設定だとトークン発行/検証がエラーになる）。
+# .env.local に設定するか、以下のコメントを外して実際の値を設定すること。
+# Environment=JWT_SECRET=<openssl rand -base64 32 で生成した値>
 ExecStart=/usr/bin/npm run start
 Restart=on-failure
 RestartSec=5

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -43,6 +43,11 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 ```
 
+**JWT_SECRETは本番（NODE_ENV=production）で必須。** 未設定の場合、トークンの発行・検証が
+`JWT_SECRET environment variable must be set in production` というエラーで失敗し、
+ログイン・拡張機能連携が動作しない（公開フォールバック鍵によるトークン偽造を防ぐためのフェイルファスト）。
+`openssl rand -base64 32` で生成した値を`.env.local`または systemd unit の`Environment=`で設定すること。
+
 ### 4. ビルド
 
 ```bash

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,8 +4,25 @@ import { cookies } from 'next/headers';
 import { getDb } from './db';
 import { auth } from '@/auth';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'butuyokuoh-secret-key-change-in-production';
 const TOKEN_COOKIE_NAME = 'butuyokuoh_token';
+
+// 開発モード専用のフォールバック鍵。リポジトリに公開されている値のため、
+// 本番でこの鍵を使うとトークンを偽造される。本番では JWT_SECRET の設定を必須とする。
+const DEV_FALLBACK_SECRET = 'butuyokuoh-secret-key-change-in-production';
+
+// 署名・検証鍵は呼び出し時に評価する（フェイルファスト）。
+// モジュールトップレベルで throw すると Next.js のビルド（NODE_ENV=production）が
+// 落ちる恐れがあるため、トークン発行/検証のタイミングで検証する。
+function getJwtSecret(): string {
+  const secret = process.env.JWT_SECRET;
+  if (secret) return secret;
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(
+      'JWT_SECRET environment variable must be set in production. Generate one with: openssl rand -base64 32'
+    );
+  }
+  return DEV_FALLBACK_SECRET;
+}
 
 export interface User {
   id: number;
@@ -30,14 +47,17 @@ export async function verifyPassword(password: string, hash: string): Promise<bo
 export function generateToken(user: User): string {
   return jwt.sign(
     { userId: user.id, email: user.email } as JWTPayload,
-    JWT_SECRET,
+    getJwtSecret(),
     { expiresIn: '7d' }
   );
 }
 
 export function verifyToken(token: string): JWTPayload | null {
+  // 鍵の取得は try の外で行う。本番で JWT_SECRET 未設定の場合に
+  // 設定エラーを null（検証失敗）として握りつぶさず、明確に throw させる。
+  const secret = getJwtSecret();
   try {
-    return jwt.verify(token, JWT_SECRET) as JWTPayload;
+    return jwt.verify(token, secret) as JWTPayload;
   } catch {
     return null;
   }


### PR DESCRIPTION
## 脆弱性の内容

`src/lib/auth.ts` に `process.env.JWT_SECRET || 'butuyokuoh-secret-key-change-in-production'` というハードコードのフォールバック鍵があった。この値は公開リポジトリに含まれるため、JWT_SECRET 未設定の本番環境ではこの公開鍵でトークンが署名・検証され、**任意の userId のトークンを偽造できる**。

`/api/extension-add` と `/api/extension-import` は CORS `*` + ボディ内トークン認証のため、偽造トークンで任意ユーザーのリストへ書き込みが可能だった。また `butuyokuoh.service` に JWT_SECRET の定義がなく、本番でフォールバックが使われている可能性が高い。

## 修正内容

- **src/lib/auth.ts**: 鍵取得を `getJwtSecret()` 関数に集約し、`NODE_ENV === 'production'` かつ `JWT_SECRET` 未設定の場合は `JWT_SECRET environment variable must be set in production. Generate one with: openssl rand -base64 32` というエラーで throw する（フェイルファスト）
  - モジュールトップレベルではなく**呼び出し時に評価**するため、`next build`（NODE_ENV=production 評価）は落ちない
  - `verifyToken` では鍵取得を try の外に出し、設定エラーを「検証失敗（null）」として握りつぶさず明確に throw させる
  - 開発モード（NODE_ENV != production）は従来どおりフォールバック鍵で動作（DX 維持）
- **butuyokuoh.service**: `Environment=JWT_SECRET=` 設定のコメント例を追記（実際の鍵は含めない）
- **docs/deployment.md**: JWT_SECRET が本番必須である旨と未設定時の挙動を追記

## 動作確認

| ケース | 結果 |
|---|---|
| `NODE_ENV=production` + JWT_SECRET 未設定 | generateToken / verifyToken が明確なエラーで throw（OK） |
| `NODE_ENV=production` + JWT_SECRET 設定済み | トークン発行・検証とも正常（OK） |
| NODE_ENV 未設定（開発相当）+ JWT_SECRET 未設定 | フォールバック鍵で従来どおり動作（OK） |
| `npm run build`（JWT_SECRET 未設定） | exit 0、ビルド成功（OK） |
| `npx tsc --noEmit` | パス（OK) |

## マージ後の運用注意（重要）

**本番サーバに JWT_SECRET の設定が必要。** 未設定のままデプロイすると、トークン発行・検証（ログイン、拡張機能連携）が即エラーになる。デプロイ前に以下を実施すること:

1. `openssl rand -base64 32` で鍵を生成
2. `/home/exedev/butuyokuoh/.env.local` に `JWT_SECRET=<生成した値>` を設定（または systemd unit の `Environment=` で設定）
3. `sudo systemctl restart butuyokuoh`

なお、現在の本番がフォールバック鍵で運用されていた場合、新しい鍵の設定により**既存の発行済みトークン（ログインセッション・拡張機能のトークン）は無効になる**。ユーザーは再ログインが必要になるが、これは鍵ローテーションとして意図した挙動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)