### PR TITLE
feat: スクレイプ結果(last_scraped_at/scrape_status/scrape_error)を記録 (#33)

### DIFF
--- a/scripts/check-prices.ts
+++ b/scripts/check-prices.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3';
 import path from 'path';
-import { scrapeUrl } from '../src/lib/scraper';
+import { scrapeUrl, deriveScrapeOutcome } from '../src/lib/scraper';
 import { sendSlackNotification, sendDiscordNotification, NotificationPayload } from '../src/lib/notifier';
 
 const dbPath = path.join(process.cwd(), 'data', 'butuyokuoh.db');
@@ -41,21 +41,36 @@ async function checkPrices() {
       console.log(`Checking: ${item.name.substring(0, 50)}...`);
       
       const scraped = await scrapeUrl(item.url);
-      
+
+      // スクレイプ結果（成功/失敗）を導出
+      const outcome = deriveScrapeOutcome(scraped);
+
       if (!scraped.price) {
-        console.log(`  - No price found, skipping`);
+        // 価格が取れなかった場合も last_scraped_at と失敗ステータスを記録する
+        db.prepare(`
+          UPDATE items
+          SET last_scraped_at = datetime('now'),
+              scrape_status = ?,
+              scrape_error = ?
+          WHERE id = ?
+        `).run(outcome.status, outcome.error, item.id);
+        console.log(`  - No price found (${outcome.error}), recorded as failed`);
         continue;
       }
 
       const oldPrice = item.current_price;
       const newPrice = scraped.price;
 
-      // 価格を更新
+      // 価格を更新（合わせてスクレイプ成功を記録）
       db.prepare(`
-        UPDATE items 
-        SET current_price = ?, updated_at = datetime('now')
+        UPDATE items
+        SET current_price = ?,
+            last_scraped_at = datetime('now'),
+            scrape_status = ?,
+            scrape_error = ?,
+            updated_at = datetime('now')
         WHERE id = ?
-      `).run(newPrice, item.id);
+      `).run(newPrice, outcome.status, outcome.error, item.id);
 
       // 価格履歴に追加
       db.prepare(`

--- a/scripts/check-prices.ts
+++ b/scripts/check-prices.ts
@@ -1,10 +1,11 @@
-import Database from 'better-sqlite3';
-import path from 'path';
+import { getDb } from '../src/lib/db';
 import { scrapeUrl, deriveScrapeOutcome } from '../src/lib/scraper';
 import { sendSlackNotification, sendDiscordNotification, NotificationPayload } from '../src/lib/notifier';
 
-const dbPath = path.join(process.cwd(), 'data', 'butuyokuoh.db');
-const db = new Database(dbPath);
+// getDb() 経由で取得することで initDb/migrateDb が実行され、
+// 新カラム（last_scraped_at/scrape_status/scrape_error）への UPDATE が
+// マイグレーション未実行の既存DBでも失敗しないようにする
+const db = getDb();
 
 interface Item {
   id: number;

--- a/src/app/api/items/[id]/refresh/route.ts
+++ b/src/app/api/items/[id]/refresh/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/db';
-import { scrapeUrl } from '@/lib/scraper';
+import { scrapeUrl, deriveScrapeOutcome } from '@/lib/scraper';
 import { getCurrentUser } from '@/lib/auth';
 
 interface DbItem {
@@ -28,7 +28,10 @@ export async function POST(
 
   // 再スクレイピング
   const scraped = await scrapeUrl(item.url);
-  
+
+  // スクレイプ結果（成功/失敗）を導出（check-prices と共通ロジック）
+  const outcome = deriveScrapeOutcome(scraped);
+
   // スクレイピング結果を更新（商品名、価格、画像）
   const updates: string[] = [];
   const values: unknown[] = [];
@@ -43,7 +46,7 @@ export async function POST(
   if (scraped.price) {
     updates.push('current_price = ?');
     values.push(scraped.price);
-    
+
     // 価格が変わった場合のみ履歴に追加
     if (scraped.price !== item.current_price) {
       db.prepare('INSERT INTO price_history (item_id, price) VALUES (?, ?)').run(id, scraped.price);
@@ -56,12 +59,17 @@ export async function POST(
     values.push(scraped.imageUrl);
   }
 
-  // 更新がある場合のみ実行
-  if (updates.length > 0) {
-    updates.push("updated_at = datetime('now')");
-    values.push(id);
-    db.prepare(`UPDATE items SET ${updates.join(', ')} WHERE id = ?`).run(...values);
-  }
+  // スクレイプ結果は成功/失敗にかかわらず常に記録する
+  updates.push('last_scraped_at = datetime(\'now\')');
+  updates.push('scrape_status = ?');
+  values.push(outcome.status);
+  updates.push('scrape_error = ?');
+  values.push(outcome.error);
+
+  // updated_at を更新して実行
+  updates.push("updated_at = datetime('now')");
+  values.push(id);
+  db.prepare(`UPDATE items SET ${updates.join(', ')} WHERE id = ?`).run(...values);
 
   const updated = db.prepare('SELECT * FROM items WHERE id = ?').get(id) as Record<string, unknown>;
   return NextResponse.json({ ...updated, note: scraped.note });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -47,6 +47,9 @@ function initDb(db: Database.Database) {
       target_currency TEXT DEFAULT 'JPY',
       quantity INTEGER NOT NULL DEFAULT 1,
       sort_order INTEGER NOT NULL DEFAULT 0,
+      last_scraped_at TEXT,
+      scrape_status TEXT,
+      scrape_error TEXT,
       deleted_at TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       updated_at TEXT NOT NULL DEFAULT (datetime('now')),
@@ -126,6 +129,10 @@ function initDb(db: Database.Database) {
 function migrateDb(db: Database.Database) {
   addColumnIfNotExists(db, 'items', 'quantity', 'INTEGER NOT NULL DEFAULT 1');
   addColumnIfNotExists(db, 'items', 'sort_order', 'INTEGER NOT NULL DEFAULT 0');
+  // スクレイプ結果の記録用カラム
+  addColumnIfNotExists(db, 'items', 'last_scraped_at', 'TEXT');
+  addColumnIfNotExists(db, 'items', 'scrape_status', 'TEXT');
+  addColumnIfNotExists(db, 'items', 'scrape_error', 'TEXT');
 }
 
 // テーブルに指定カラムが存在しない場合のみ ALTER TABLE で追加する

--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -10,6 +10,22 @@ export interface ScrapedItem {
   note?: string; // ユーザーへのメッセージ（短縮リンクの制限など）
 }
 
+// スクレイプ結果から items テーブルに記録する状態を導出する。
+// check-prices と refresh API の双方で共有し、記録ロジックを統一する。
+export interface ScrapeOutcome {
+  status: 'success' | 'failed';
+  error: string | null;
+}
+
+export function deriveScrapeOutcome(scraped: ScrapedItem): ScrapeOutcome {
+  if (scraped.price) {
+    return { status: 'success', error: null };
+  }
+  // 価格が取れなかった場合は失敗扱い。理由は scraper の note を優先し、
+  // なければ汎用メッセージにフォールバックする。
+  return { status: 'failed', error: scraped.note ?? 'price not found' };
+}
+
 // 許可されたAmazonドメイン
 const AMAZON_DOMAINS = new Set([
   'www.amazon.co.jp',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,6 +21,9 @@ export interface Item {
   target_currency: 'JPY' | 'USD' | null;
   quantity: number;
   sort_order?: number;
+  last_scraped_at?: string | null; // 最後にスクレイプを試みた日時
+  scrape_status?: 'success' | 'failed' | null; // 直近スクレイプの成否
+  scrape_error?: string | null; // 失敗理由（任意）
   deleted_at: string | null;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## 概要

価格スクレイピングの試行結果（いつ試したか・成功/失敗・失敗理由）を `items` テーブルに記録できるようにした。後続の ItemCard 表示タスクの基盤となる。

## 変更内容

- `src/lib/db.ts`
  - `items` の CREATE TABLE に `last_scraped_at TEXT` / `scrape_status TEXT` / `scrape_error TEXT` を追加（新規DB対応）
  - `migrateDb()` に `addColumnIfNotExists` で同3カラムを追加（既存DBへのマイグレーション）
- `src/lib/scraper.ts`
  - `deriveScrapeOutcome(scraped)` を追加。価格が取れたら `success`/`error=null`、取れなければ `failed` とし、理由は `note` を優先、なければ `'price not found'` にフォールバックする。check-prices と refresh で共有する共通ロジック
- `scripts/check-prices.ts`
  - 各アイテムのスクレイプ後、成功/失敗にかかわらず `last_scraped_at` を `datetime('now')` で更新
  - 成功時: `current_price` 更新と合わせて `scrape_status='success'` / `scrape_error=NULL`
  - 失敗時（価格なし）: 従来 skip していた箇所で `scrape_status='failed'` / `scrape_error` を記録してから continue
  - 既存の価格更新・price_history 追加・通知ロジックは変更なし
- `src/app/api/items/[id]/refresh/route.ts`（手動更新）
  - 同じ `deriveScrapeOutcome` を使い、成功/失敗にかかわらず `last_scraped_at` / `scrape_status` / `scrape_error` を常に記録
- `src/types/index.ts`
  - `Item` 型に `last_scraped_at` / `scrape_status` / `scrape_error` を追加（GET /api/items は `i.*` を返すため新カラムが含まれる）

## 動作確認

実Amazon等へはアクセスせず、`scrapeUrl` をスタブ化したワンオフ検証スクリプト（コミット対象外）で確認。

- マイグレーション: 新3カラムを欠いた既存DBに対し `getDb()` 初期化時のマイグレーションで `last_scraped_at` / `scrape_status` / `scrape_error` が追加され、既存行も保持されることを確認（PASS）
- check-prices 成功ケース: `current_price=1980` / `scrape_status='success'` / `scrape_error=null` / `last_scraped_at` が記録される（PASS）
- check-prices 失敗ケース（note なし）: `scrape_status='failed'` / `scrape_error='price not found'` / `last_scraped_at` が記録される（PASS）
- check-prices 失敗ケース（note あり、例: bot 検出）: `scrape_status='failed'` / `scrape_error='bot detected'`（note を採用）/ `last_scraped_at` が記録される（PASS）
- `npx tsc --noEmit` 相当（`node_modules/.bin/tsc --noEmit`）パス
- `npm run build` パス（lint の既存エラー/警告は本変更と無関係）

UI 表示は別タスクのため Closes ではなく Refs にしている。

Refs #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)