### PR TITLE
perf: アイテム画像に loading=lazy / decoding=async を付与 (#36)

### DIFF
--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -151,9 +151,11 @@ export default function ItemCard({ item, onUpdate, onDelete, categories = [], co
         {/* 画像 */}
         <div className="w-32 h-32 flex-shrink-0 bg-gray-100 dark:bg-slate-700">
           {item.image_url ? (
-            <img 
-              src={item.image_url} 
+            <img
+              src={item.image_url}
               alt={item.name}
+              loading="lazy"
+              decoding="async"
               className="w-full h-full object-contain"
             />
           ) : (

--- a/src/components/PurchasedHistory.tsx
+++ b/src/components/PurchasedHistory.tsx
@@ -106,6 +106,8 @@ export default function PurchasedHistory() {
                     <img
                       src={item.image_url}
                       alt={item.name}
+                      loading="lazy"
+                      decoding="async"
                       className="w-full h-full object-contain rounded"
                     />
                   ) : (

--- a/src/components/TrashView.tsx
+++ b/src/components/TrashView.tsx
@@ -81,6 +81,8 @@ export default function TrashView() {
                   <img
                     src={item.image_url}
                     alt={item.name}
+                    loading="lazy"
+                    decoding="async"
                     className="w-full h-full object-contain rounded opacity-60"
                   />
                 ) : (


### PR DESCRIPTION
## 概要

一覧に描画される商品画像の `<img>` 要素に `loading="lazy"` と `decoding="async"` を付与し、初期表示時の一斉ロードを抑制して LCP / データ転送を改善する。表示の見た目・レイアウトは変更せず属性追加のみ。

## 対象 img 箇所

| ファイル | 箇所 | 用途 |
| --- | --- | --- |
| `src/components/ItemCard.tsx` | 154行目付近 | 一覧アイテムの商品画像 |
| `src/components/PurchasedHistory.tsx` | 106行目付近 | 購入履歴一覧の商品画像 |
| `src/components/TrashView.tsx` | 81行目付近 | ゴミ箱一覧の商品画像 |

いずれも一覧で全件描画される商品画像。ファーストビュー固定の重要画像やフォームのプレビュー画像（編集フォーム・追加画面・価格チャート）には付与していない。

## 動作確認

- `npx tsc --noEmit` パス
- `npm run build` パス（Compiled successfully）
- `git diff` で属性追加のみ・他の変更が無いことを確認

Refs #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)