### PR TITLE
fix: getDb() で data/ ディレクトリを自動作成する

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,4 +1,5 @@
 import Database from 'better-sqlite3';
+import fs from 'fs';
 import path from 'path';
 
 const dbPath = path.join(process.cwd(), 'data', 'butuyokuoh.db');
@@ -7,6 +8,8 @@ let db: Database.Database | null = null;
 
 export function getDb(): Database.Database {
   if (!db) {
+    // data/ ディレクトリが存在しない新規環境でも DB を初期化できるように自動作成する
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
     db = new Database(dbPath);
     db.pragma('journal_mode = WAL');
     initDb(db);


### PR DESCRIPTION
## 概要

`getDb()` が `new Database(dbPath)` を呼ぶ直前に `data/` ディレクトリを自動作成するようにしました。これにより、`data/` が存在しない新規クローン環境でも `getDb()` が例外を出さずに DB を初期化できます。

従来は `data/` が無いと `Cannot open database because the directory does not exist` で例外になり、README 手順の `mkdir -p data` が必須でしたが、コード側で堅牢に対応します（周回1の tester 指摘対応）。

## 変更内容

- `src/lib/db.ts` の冒頭に `import fs from 'fs';` を追加
- `getDb()` 内、`new Database(dbPath)` の直前に `fs.mkdirSync(path.dirname(dbPath), { recursive: true })` を追加
  - `recursive: true` のため、既に `data/` が存在してもエラーになりません

**db.ts の getDb() 関数のみ変更（PR #47 とのコンフリクト回避）**。CREATE TABLE / initDb / migrateDb / addColumnIfNotExists などスキーマ定義箇所には一切触れていません。

## 動作確認

- `data/` を作らない一時 cwd から `getDb()` を実行 → 例外なく DB 初期化、`data/` および DB ファイルが自動作成されることを確認（RESULT: OK）
- 同一 cwd で再実行（`data/` 既存）→ 例外なく DB 初期化されることを確認（RESULT: OK）
- `npx tsc --noEmit` パス
- `npm run build` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)