### PR TITLE
fix: /api/upload の拡張子・MIME検証を強化しSVG/HTML偽装を防ぐ

### DIFF
--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -4,6 +4,84 @@ import { writeFile, mkdir } from 'fs/promises';
 import path from 'path';
 import { existsSync } from 'fs';
 
+// 許可する拡張子と MIME タイプの対応表（svg は XSS 対策のため明示的に除外）
+const ALLOWED_EXTENSIONS: Record<string, string[]> = {
+  jpg: ['image/jpeg'],
+  jpeg: ['image/jpeg'],
+  png: ['image/png'],
+  webp: ['image/webp'],
+  gif: ['image/gif'],
+  avif: ['image/avif'],
+};
+
+// 許可する MIME タイプの一覧
+const ALLOWED_MIME_TYPES = new Set(
+  Object.values(ALLOWED_EXTENSIONS).flat()
+);
+
+// 拡張子の正規パターン（英数字 1〜5 文字のみ。/ や .. や空文字を弾く）
+const EXT_PATTERN = /^[a-z0-9]{1,5}$/;
+
+/**
+ * バッファの先頭バイト（マジックバイト）から実体が画像かを簡易判定する。
+ * 拡張子・MIME 偽装（SVG/HTML を画像と偽る）への二重防御。
+ * 戻り値: 判定できた拡張子（jpg/png/gif/webp/avif）または null
+ */
+function detectImageType(buffer: Buffer): string | null {
+  if (buffer.length < 12) {
+    return null;
+  }
+
+  // JPEG: FF D8 FF
+  if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return 'jpg';
+  }
+
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  ) {
+    return 'png';
+  }
+
+  // GIF: "GIF87a" または "GIF89a"
+  if (
+    buffer[0] === 0x47 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x38 &&
+    (buffer[4] === 0x37 || buffer[4] === 0x39) &&
+    buffer[5] === 0x61
+  ) {
+    return 'gif';
+  }
+
+  // WEBP: "RIFF" .... "WEBP"
+  if (
+    buffer.toString('ascii', 0, 4) === 'RIFF' &&
+    buffer.toString('ascii', 8, 12) === 'WEBP'
+  ) {
+    return 'webp';
+  }
+
+  // AVIF: 先頭 4 バイトは box size、続く "ftyp" の後にブランド "avif"/"avis"
+  if (buffer.toString('ascii', 4, 8) === 'ftyp') {
+    const brand = buffer.toString('ascii', 8, 12);
+    if (brand === 'avif' || brand === 'avis') {
+      return 'avif';
+    }
+  }
+
+  return null;
+}
+
 export async function POST(request: NextRequest) {
   const user = await getCurrentUser();
   if (!user) {
@@ -18,9 +96,21 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'ファイルがありません' }, { status: 400 });
     }
 
-    // ファイルタイプチェック
-    if (!file.type.startsWith('image/')) {
-      return NextResponse.json({ error: '画像ファイルのみアップロード可能です' }, { status: 400 });
+    // 拡張子をファイル名から取得し、サニタイズ・検証する
+    // （/ や .. の混入によるパストラバーサル、許可外拡張子を弾く）
+    const rawExt = file.name.split('.').pop()?.toLowerCase() ?? '';
+    if (!EXT_PATTERN.test(rawExt) || !(rawExt in ALLOWED_EXTENSIONS)) {
+      return NextResponse.json({ error: '対応していない画像形式です' }, { status: 400 });
+    }
+
+    // MIME タイプを許可リストでチェック（file.type はクライアント任意のため過信しない）
+    if (!ALLOWED_MIME_TYPES.has(file.type)) {
+      return NextResponse.json({ error: '対応していない画像形式です' }, { status: 400 });
+    }
+
+    // 拡張子と MIME の整合性を確認（例: .png なのに image/jpeg を弾く）
+    if (!ALLOWED_EXTENSIONS[rawExt].includes(file.type)) {
+      return NextResponse.json({ error: '対応していない画像形式です' }, { status: 400 });
     }
 
     // ファイルサイズチェック (5MB以下)
@@ -31,10 +121,24 @@ export async function POST(request: NextRequest) {
     const bytes = await file.arrayBuffer();
     const buffer = Buffer.from(bytes);
 
-    // ユニークなファイル名を生成
-    const ext = file.name.split('.').pop() || 'jpg';
+    // マジックバイトで実体が画像かを検証（SVG/HTML 偽装を弾く三重目の防御）
+    const detected = detectImageType(buffer);
+    if (!detected) {
+      return NextResponse.json({ error: '画像ファイルとして認識できません' }, { status: 400 });
+    }
+
+    // 検出した実体に基づいて拡張子を決定する。
+    // jpg/jpeg は同一実体のため、宣言された拡張子を尊重しつつ実体と矛盾しないものを採用。
+    const detectedSet = detected === 'jpg' ? ['jpg', 'jpeg'] : [detected];
+    if (!detectedSet.includes(rawExt)) {
+      return NextResponse.json({ error: '拡張子とファイルの内容が一致しません' }, { status: 400 });
+    }
+    // 保存に使う拡張子は検証済みのもののみ（ユーザー入力のファイル名本体は使わない）
+    const ext = rawExt;
+
+    // ユニークなファイル名をサーバ側で生成（ユーザー入力のファイル名本体は保存パスに使わない）
     const filename = `${user.id}_${Date.now()}.${ext}`;
-    
+
     // アップロードディレクトリの確認/作成
     const uploadDir = path.join(process.cwd(), 'public', 'uploads');
     if (!existsSync(uploadDir)) {


### PR DESCRIPTION
## 概要
`src/app/api/upload/route.ts` のファイル検証が不十分で、stored XSS とパストラバーサルのリスクがあったため修正した。

## 脆弱性の内容
1. **type 偽装による stored XSS**
   - 修正前は `file.type.startsWith('image/')` のみで判定していた。`file.type` はクライアントが自由に設定可能なため、`image/svg+xml` を名乗る SVG（`<script>` 埋め込み可能）や、type を `image/*` に偽装した HTML が `public/uploads` に保存され、同一オリジンから配信されて stored XSS になりうる。
2. **パストラバーサル**
   - 修正前は `file.name.split('.').pop()` を未サニタイズで拡張子に使用していた。拡張子部分に `/` や `..` が混入すると保存パスが `uploads/` 直下から外れる恐れがあった。

## 修正内容
1. **拡張子の許可リスト**を導入: `jpg / jpeg / png / webp / gif / avif` のみ許可。**svg は明示的に除外**。許可外は 400。
2. 拡張子は `file.name` から取得後に小文字化し、`^[a-z0-9]{1,5}$` で検証。`/`・`..`・空・異常に長い拡張子を弾く。
3. **MIME 許可リスト**（image/jpeg, image/png, image/webp, image/gif, image/avif）でチェック。さらに拡張子と MIME の整合性も確認（例: `.png` なのに `image/jpeg` を弾く）。`file.type` は過信しない。
4. **マジックバイト検証を採用**: 先頭バイトで実体が画像かを簡易確認する三重目の防御を実装。
   - JPEG: `FF D8 FF` / PNG: `89 50 4E 47 0D 0A 1A 0A` / GIF: `GIF87a`/`GIF89a` / WEBP: `RIFF....WEBP` / AVIF: `....ftyp(avif|avis)`
   - 検出した実体と宣言拡張子が一致しない場合も 400（jpg/jpeg は同一実体として許容）。
5. 保存ファイル名は従来どおりサーバ側生成（`${user.id}_${Date.now()}.${ext}`）。`ext` は検証済みのもののみを使用し、ユーザー入力のファイル名本体は保存パスに一切使わない。
6. 400 時のレスポンスは既存のエラー形式（`{ error: '...' }` + status 400）に合わせた。

保存先 `public/uploads`、返す URL の形 `/uploads/<filename>` は従来どおり変更なし。

## 採用した検証方式
拡張子許可リスト + MIME 許可リスト + 拡張子/MIME 整合 + **マジックバイト実体検証** の四段構え。マジックバイト検証も実装済み。

## 動作確認結果
- `npx tsc --noEmit`（ローカル tsc）: パス
- `npm run build`: パス
- 検証ロジックを単体抽出してテスト（13+ ケース、全 PASS）:
  - `.svg`（image/svg+xml）→ 400
  - `.svg` で type を image/png に偽装 + PNG マジックバイト → 400（拡張子で拒否）
  - `.html`（type を image/png に偽装）→ 400
  - `.php` → 400
  - 拡張子なし / 異常に長い拡張子 → 400
  - ファイル名 `../../etc/passwd`、拡張子に `/` を含む `evil.jp/g` → 400（拡張子検証で拒否。保存ファイル名はサーバ生成のため uploads/ 直下に限定されパストラバーサル不可）
  - `.png` 拡張子だが JPEG 実体 → 400（拡張子/実体不一致）
  - `.jpg` 拡張子だが HTML 実体 → 400（マジックバイト不一致）
  - 正常な jpg / jpeg / png / gif / webp（正しいマジックバイト）→ 成功し `/uploads/<filename>` が返る

## 変更ファイル
- `src/app/api/upload/route.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)