### PR TITLE
fix: 比較グループの編集/削除API (comparison-groups/[id]) を追加し404を解消

### DIFF
--- a/src/app/api/comparison-groups/[id]/route.ts
+++ b/src/app/api/comparison-groups/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb } from '@/lib/db';
+import { getCurrentUser } from '@/lib/auth';
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const { name, priority } = await request.json();
+
+  const db = getDb();
+
+  // 所有権確認
+  const group = db.prepare('SELECT * FROM comparison_groups WHERE id = ? AND user_id = ?').get(id, user.id);
+  if (!group) {
+    return NextResponse.json({ error: '比較グループが見つかりません' }, { status: 404 });
+  }
+
+  db.prepare(`
+    UPDATE comparison_groups
+    SET name = COALESCE(?, name),
+        priority = COALESCE(?, priority)
+    WHERE id = ? AND user_id = ?
+  `).run(name, priority, id, user.id);
+
+  const updated = db.prepare('SELECT * FROM comparison_groups WHERE id = ?').get(id);
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const db = getDb();
+
+  // 所有権確認
+  const group = db.prepare('SELECT * FROM comparison_groups WHERE id = ? AND user_id = ?').get(id, user.id);
+  if (!group) {
+    return NextResponse.json({ error: '比較グループが見つかりません' }, { status: 404 });
+  }
+
+  // 紐づくアイテムのcomparison_group_idをnullに
+  db.prepare('UPDATE items SET comparison_group_id = NULL WHERE comparison_group_id = ? AND user_id = ?').run(id, user.id);
+
+  // 比較グループ削除
+  db.prepare('DELETE FROM comparison_groups WHERE id = ? AND user_id = ?').run(id, user.id);
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/comparison-groups/[id]/route.ts
+++ b/src/app/api/comparison-groups/[id]/route.ts
@@ -51,11 +51,13 @@ export async function DELETE(
     return NextResponse.json({ error: '比較グループが見つかりません' }, { status: 404 });
   }
 
-  // 紐づくアイテムのcomparison_group_idをnullに
-  db.prepare('UPDATE items SET comparison_group_id = NULL WHERE comparison_group_id = ? AND user_id = ?').run(id, user.id);
-
-  // 比較グループ削除
-  db.prepare('DELETE FROM comparison_groups WHERE id = ? AND user_id = ?').run(id, user.id);
+  // 紐づくアイテムのcomparison_group_idのnull化とグループ削除を
+  // 1トランザクションにまとめ、途中失敗による不整合を防ぐ
+  const deleteGroup = db.transaction(() => {
+    db.prepare('UPDATE items SET comparison_group_id = NULL WHERE comparison_group_id = ? AND user_id = ?').run(id, user.id);
+    db.prepare('DELETE FROM comparison_groups WHERE id = ? AND user_id = ?').run(id, user.id);
+  });
+  deleteGroup();
 
   return NextResponse.json({ success: true });
 }


### PR DESCRIPTION
## バグ内容

`src/app/settings/page.tsx` は比較グループの編集・削除のため以下を呼ぶが、`/api/comparison-groups/[id]/route.ts` が存在せず **両方とも404で機能しなかった**。

- `handleUpdateGroup`: `PUT /api/comparison-groups/{id}` ボディ `{ name }`
- `handleDeleteGroup`: `DELETE /api/comparison-groups/{id}`

## 修正内容

新規ファイル `src/app/api/comparison-groups/[id]/route.ts` を作成し、`categories/[id]/route.ts` と同じ流儀で実装。

### PUT（編集）
- `getCurrentUser()` で認証、未認証は 401
- `SELECT * FROM comparison_groups WHERE id = ? AND user_id = ?` で所有権確認、無ければ 404（`比較グループが見つかりません`）
- `name` / `priority` を `COALESCE(?, col)` で更新し、更新後の行を返す

### DELETE（削除）
- 認証・所有権確認（同上、未所有 404）
- 紐づくアイテムの `comparison_group_id` を NULL 化（防御的に `AND user_id = ?` を付与）
  - `UPDATE items SET comparison_group_id = NULL WHERE comparison_group_id = ? AND user_id = ?`
- `DELETE FROM comparison_groups WHERE id = ? AND user_id = ?`
- `{ success: true }` を返す

params の型は `{ params }: { params: Promise<{ id: string }> }`（Next.js 16）に統一。settings/page.tsx 側は変更不要。

## 動作確認

- `npx tsc --noEmit` パス
- `npm run build` パス（`/api/comparison-groups/[id]` がビルド出力に出現）
- dev サーバ + curl で検証（検証用 data/ はコミットに含めず削除済み）:
  - 編集成功: グループ作成 → `PUT { name }` → **HTTP 200**、GET で名前変更が反映
  - 削除でNULL化: グループにアイテム紐付け → `DELETE` → **HTTP 200**、グループ消滅 & アイテムの `comparison_group_id` が `null` になることを確認
  - 他ユーザー所有権: ユーザーBがユーザーAのグループに `PUT`/`DELETE` → **HTTP 404**（Aのグループは無傷）
  - 未認証: Cookie なしで `PUT`/`DELETE` → **HTTP 401**

🤖 Generated with [Claude Code](https://claude.com/claude-code)