### PR TITLE
fix: 価格ソートで価格未取得アイテムを末尾に並べる

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -301,9 +301,15 @@ export default function Home() {
     .sort((a, b) => {
       switch (sortBy) {
         case 'price_asc':
-          return (a.current_price || 0) - (b.current_price || 0);
-        case 'price_desc':
-          return (b.current_price || 0) - (a.current_price || 0);
+        case 'price_desc': {
+          // 価格未取得(null/undefined)はasc/descいずれでも末尾に並べる
+          const av = a.current_price;
+          const bv = b.current_price;
+          if (av == null && bv == null) return 0;
+          if (av == null) return 1;
+          if (bv == null) return -1;
+          return sortBy === 'price_asc' ? av - bv : bv - av;
+        }
         case 'date_new':
           return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
         case 'date_old':


### PR DESCRIPTION
## 変更概要

価格ソート（`price_asc` / `price_desc`）で `current_price` が `null`/`undefined` のアイテムを `0` として扱っていたため、価格未取得アイテムが「価格が安い順」で先頭に集まり、購入判断の一等地を占拠していた。価格未取得アイテムが asc/desc いずれでも末尾に並ぶよう比較ロジックを修正した。

## 変更箇所

- `src/app/page.tsx` (303-312行目付近) のソート比較関数
  - `price_asc` / `price_desc` の case を統合し、`current_price` が `null`/`undefined` の場合は常に末尾になるよう比較
  - 両方 null → 0（相対順序維持・安定ソート）
  - 一方だけ null → null 側を後ろ（asc/desc 共通）
  - 両方値あり → 従来通り（asc: 昇順 / desc: 降順）
- price 以外のソート（優先度・日付・名前）の挙動は変更なし

## before / after の並び

サンプル `[1000, null, 500, null, 2000]` の場合:

| ソート | before | after |
| --- | --- | --- |
| price_asc | `[null, null, 500, 1000, 2000]` | `[500, 1000, 2000, null, null]` |
| price_desc | `[2000, 1000, 500, null, null]` | `[2000, 1000, 500, null, null]` |

※ before の asc では null（→0扱い）が先頭に来ていた。

## 動作確認結果

- `npx tsc --noEmit` パス
- `npm run build` パス
- 比較関数を抽出したワンオフ検証（コミット非対象）:
  - `price_asc`: `[500,1000,2000,null,null]`
  - `price_desc`: `[2000,1000,500,null,null]`
  - `undefined` も null 同様に末尾に並ぶことを確認
- `git diff` で差分が `price_asc`/`price_desc` の比較のみであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)