### PR TITLE
feat: 価格チャートに目標価格の基準線を表示 (PriceChart)

### DIFF
--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -292,7 +292,13 @@ export default function ItemCard({ item, onUpdate, onDelete, categories = [], co
       {/* 価格チャート */}
       {showChart && (
         <div className="p-4 border-t">
-          <PriceChart itemId={item.id} url={item.url} source={item.source} />
+          <PriceChart
+            itemId={item.id}
+            url={item.url}
+            source={item.source}
+            targetPrice={item.target_price}
+            targetCurrency={item.target_currency}
+          />
         </div>
       )}
 

--- a/src/components/PriceChart.tsx
+++ b/src/components/PriceChart.tsx
@@ -220,7 +220,7 @@ export default function PriceChart({ itemId, url, source, targetPrice, targetCur
   const showTargetLine = hasTarget && targetIsJpy;
   const yDomain: [number | string, number | string] = showTargetLine
     ? [
-        targetPrice! < minPrice ? targetPrice! - 100 : 'dataMin - 100',
+        targetPrice! < minPrice ? Math.max(0, targetPrice! - 100) : 'dataMin - 100',
         targetPrice! > maxPrice ? targetPrice! + 100 : 'dataMax + 100',
       ]
     : ['dataMin - 100', 'dataMax + 100'];

--- a/src/components/PriceChart.tsx
+++ b/src/components/PriceChart.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine } from 'recharts';
 import { format } from 'date-fns';
 import { ja } from 'date-fns/locale';
 import { PriceHistory } from '@/types';
@@ -10,6 +10,8 @@ interface PriceChartProps {
   itemId: number;
   url?: string;
   source?: string;
+  targetPrice?: number | null;
+  targetCurrency?: 'JPY' | 'USD' | null;
 }
 
 // AmazonのURLからASINを抽出
@@ -49,10 +51,17 @@ function isRakutenUrl(url: string | undefined): boolean {
   }
 }
 
-export default function PriceChart({ itemId, url, source }: PriceChartProps) {
+export default function PriceChart({ itemId, url, source, targetPrice, targetCurrency }: PriceChartProps) {
   const [history, setHistory] = useState<PriceHistory[]>([]);
   const [loading, setLoading] = useState(true);
   const [showKeepa, setShowKeepa] = useState(true);
+
+  // 目標価格の通貨記号（USDのみ$、それ以外は¥）
+  // 価格履歴・current_priceはJPY前提のため、目標達成判定はtarget_priceが
+  // JPYのときのみ意味を持つ。USD設定時はラベル表示のみ行い、達成判定は行わない。
+  const targetIsJpy = targetCurrency !== 'USD';
+  const hasTarget = typeof targetPrice === 'number' && targetPrice > 0;
+  const targetSymbol = targetCurrency === 'USD' ? '$' : '¥';
 
   // Amazonの場合、ASINを抽出
   const isAmazon = source === 'amazon' || isAmazonUrl(url);
@@ -161,6 +170,22 @@ export default function PriceChart({ itemId, url, source }: PriceChartProps) {
           <div className="text-center">
             <p className="text-2xl font-bold text-blue-600">¥{history[0].price.toLocaleString()}</p>
             <p className="text-xs text-gray-500 mt-1">{chartData[0].fullDate} 時点（登録時）</p>
+            {hasTarget && (
+              <p className={`text-xs mt-2 font-medium ${
+                targetIsJpy
+                  ? history[0].price <= targetPrice!
+                    ? 'text-green-600'
+                    : 'text-orange-600'
+                  : 'text-orange-600'
+              }`}>
+                🎯 目標 {targetSymbol}{targetPrice!.toLocaleString()}
+                {targetIsJpy && (
+                  history[0].price <= targetPrice!
+                    ? '（達成）'
+                    : `（あと¥${(history[0].price - targetPrice!).toLocaleString()}）`
+                )}
+              </p>
+            )}
           </div>
           {cannotAutoCollect ? (
             <p className="text-xs text-gray-400 mt-3 text-center">
@@ -176,6 +201,29 @@ export default function PriceChart({ itemId, url, source }: PriceChartProps) {
       </div>
     );
   }
+
+  // 目標価格の達成判定（最新の価格と比較）。
+  // current_price相当として履歴の最新値を使用する。
+  const latestPrice = history[history.length - 1].price;
+  const targetReached = hasTarget && targetIsJpy && latestPrice <= targetPrice!;
+  // 達成/未達をラベル文言でも判別できるようにする（色だけに依存しない）
+  const targetLabel = hasTarget
+    ? targetIsJpy
+      ? targetReached
+        ? `目標 ¥${targetPrice!.toLocaleString()}（達成）`
+        : `目標 ¥${targetPrice!.toLocaleString()}（あと¥${(latestPrice - targetPrice!).toLocaleString()}）`
+      : `目標 ${targetSymbol}${targetPrice!.toLocaleString()}`
+    : '';
+  const targetLineColor = targetReached ? '#16a34a' : '#f97316';
+
+  // 目標線がJPYかつグラフ範囲外にあるとき、見切れないようY軸domainを拡張する
+  const showTargetLine = hasTarget && targetIsJpy;
+  const yDomain: [number | string, number | string] = showTargetLine
+    ? [
+        targetPrice! < minPrice ? targetPrice! - 100 : 'dataMin - 100',
+        targetPrice! > maxPrice ? targetPrice! + 100 : 'dataMax + 100',
+      ]
+    : ['dataMin - 100', 'dataMax + 100'];
 
   return (
     <div>
@@ -198,6 +246,16 @@ export default function PriceChart({ itemId, url, source }: PriceChartProps) {
           最高値: <span className="text-red-600 font-semibold">¥{maxPrice.toLocaleString()}</span>
         </span>
       </div>
+      {hasTarget && (
+        <div className="mb-2 text-sm">
+          <span className={`font-medium ${targetReached ? 'text-green-600' : 'text-orange-600'}`}>
+            🎯 {targetLabel}
+          </span>
+          {!targetIsJpy && (
+            <span className="text-xs text-gray-400 ml-1">（USD目標のためグラフ線は非表示）</span>
+          )}
+        </div>
+      )}
       <ResponsiveContainer width="100%" height={200}>
         <LineChart data={chartData}>
           <CartesianGrid strokeDasharray="3 3" />
@@ -205,11 +263,24 @@ export default function PriceChart({ itemId, url, source }: PriceChartProps) {
           <YAxis
             tick={{ fontSize: 12 }}
             tickFormatter={(value) => `¥${value.toLocaleString()}`}
-            domain={['dataMin - 100', 'dataMax + 100']}
+            domain={yDomain}
           />
           <Tooltip
             formatter={(value) => [`¥${Number(value).toLocaleString()}`, '価格']}
           />
+          {showTargetLine && (
+            <ReferenceLine
+              y={targetPrice!}
+              stroke={targetLineColor}
+              strokeDasharray="4 4"
+              label={{
+                value: targetLabel,
+                position: 'insideTopLeft',
+                fill: targetLineColor,
+                fontSize: 11,
+              }}
+            />
+          )}
           <Line
             type="monotone"
             dataKey="price"


### PR DESCRIPTION
## 概要

価格チャート（`PriceChart`）に、ユーザーが設定した目標価格（`target_price`）の基準線を表示する。「あと何円下がれば目標達成か」がグラフ上で読み取れるようにし、価格トラッキング体験を強化する。

## 変更内容

### `src/components/PriceChart.tsx`
- recharts から `ReferenceLine` を追加 import
- props に `targetPrice?: number | null` / `targetCurrency?: 'JPY' | 'USD' | null` を追加
- 履歴2件以上のチャート表示で、目標価格（JPY）が設定されている場合 `<ReferenceLine y={targetPrice} />` で水平線（破線）+ ラベルを描画
- Y軸 `domain` を調整し、目標線がグラフ範囲外でも見切れないようにした（目標が範囲内なら従来の `dataMin - 100 / dataMax + 100` のまま）
- 最安/最高表示の下にも目標ラベルをテキスト併記
- 履歴1件の簡易表示でも、目標があれば「目標 ¥XXX（達成/あと¥YYY）」をテキスト併記

### `src/components/ItemCard.tsx`
- `PriceChart` 呼び出しに `targetPrice={item.target_price}` / `targetCurrency={item.target_currency}` を追加

## props 変更点

| prop | 型 | 説明 |
|------|----|------|
| `targetPrice` | `number \| null \| undefined` | 目標価格。未設定（null/undefined/0以下）なら従来通り線・表示なし |
| `targetCurrency` | `'JPY' \| 'USD' \| null \| undefined` | 目標通貨。表示記号と達成判定に使用 |

## 達成/未達のラベル仕様（色だけに依存しない）

最新価格（履歴の最新値、複数件のときは末尾）と目標価格を比較し、ラベル文言で判別可能にした。

- 達成（最新価格 <= 目標）: 「目標 ¥XXX（達成）」 + 緑系
- 未達（最新価格 > 目標）: 「目標 ¥XXX（あと¥YYY）」 + オレンジ系

`ReferenceLine` のラベルにも同じ文言を表示し、色（緑/オレンジ）と文言の両方で判別できる。

## 通貨の扱い

価格履歴・current_price は JPY 前提のため、**目標達成判定および基準線描画は `target_currency` が JPY のときのみ**行う。`target_currency` が USD の場合は JPY 軸に USD 値の線を引くと誤解を生むため、グラフ線は描画せず「目標 $XXX」をテキストで併記する（その旨の注記も表示）。

## 動作確認

- `npx tsc --noEmit`（ローカル tsc）: パス（エラーなし）
- `npm run build`: パス（既存の themeColor/viewport metadata 警告のみ、本変更とは無関係）
- `eslint`（変更ファイル）: エラーなし（既存の no-img-element / unused-vars 警告のみ、追加箇所に新規警告なし）
- 条件分岐の確認（diff）:
  - target なし: `hasTarget` が false となり ReferenceLine・テキスト併記とも非描画（従来通り）
  - target あり（JPY）: ReferenceLine（破線）+ ラベル + テキスト併記
  - target あり（USD）: ReferenceLine は非描画、テキスト併記のみ
  - 履歴1件: 目標があれば達成/未達テキストを併記

🤖 Generated with [Claude Code](https://claude.com/claude-code)