### PR TITLE
feat: ItemCardに価格更新ステータス（経過時間・失敗警告）を表示 (#33)

### DIFF
--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -2,8 +2,20 @@
 
 import { useState, useRef } from 'react';
 import { Item, Category, ComparisonGroup } from '@/types';
-import { Trash2, RefreshCw, ExternalLink, TrendingDown, TrendingUp, Calendar, Flag, Upload, ImageIcon } from 'lucide-react';
+import { Trash2, RefreshCw, ExternalLink, TrendingDown, TrendingUp, Calendar, Flag, Upload, ImageIcon, Clock, AlertTriangle } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import { ja } from 'date-fns/locale';
 import PriceChart from './PriceChart';
+
+// SQLite の datetime('now') 形式（UTC、'YYYY-MM-DD HH:MM:SS'）を UTC として Date にパースする。
+// タイムゾーン指定なしのまま new Date() に渡すとローカル時刻と解釈され経過時間がずれるため、
+// オフセットが無い場合は末尾に 'Z' を付与して UTC として扱う。
+function parseUtcDateTime(value: string): Date | null {
+  const normalized = value.includes('T') ? value : value.replace(' ', 'T');
+  const withZone = /Z$|[+-]\d{2}:?\d{2}$/.test(normalized) ? normalized : `${normalized}Z`;
+  const date = new Date(withZone);
+  return isNaN(date.getTime()) ? null : date;
+}
 
 interface ItemCardProps {
   item: Item;
@@ -129,9 +141,13 @@ export default function ItemCard({ item, onUpdate, onDelete, categories = [], co
 
   // 前回価格との差分（previous_priceがあればそれを使用、なければoriginal_price）
   const previousPrice = item.previous_price ?? item.original_price;
-  const priceChange = previousPrice && item.current_price 
-    ? item.current_price - previousPrice 
+  const priceChange = previousPrice && item.current_price
+    ? item.current_price - previousPrice
     : 0;
+
+  // 価格更新ステータス（last_scraped_at が無い手動アイテム等は表示しない）
+  const lastScrapedDate = item.last_scraped_at ? parseUtcDateTime(item.last_scraped_at) : null;
+  const scrapeFailed = item.scrape_status === 'failed';
 
   const sourceColors: Record<string, string> = {
     amazon: 'bg-orange-100 text-orange-800 dark:bg-orange-900/50 dark:text-orange-200',
@@ -231,6 +247,27 @@ export default function ItemCard({ item, onUpdate, onDelete, categories = [], co
               </span>
             )}
           </div>
+
+          {/* 価格更新ステータス（経過時間・失敗警告） */}
+          {(lastScrapedDate || scrapeFailed) && (
+            <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
+              {lastScrapedDate && (
+                <span className="flex items-center gap-1" title={lastScrapedDate.toLocaleString('ja-JP')}>
+                  <Clock size={12} />
+                  価格更新: {formatDistanceToNow(lastScrapedDate, { addSuffix: true, locale: ja })}
+                </span>
+              )}
+              {scrapeFailed && (
+                <span
+                  className="flex items-center gap-1 text-amber-600 dark:text-amber-400"
+                  title={item.scrape_error || '価格の取得に失敗しました'}
+                >
+                  <AlertTriangle size={12} />
+                  価格を更新できていません
+                </span>
+              )}
+            </div>
+          )}
 
           <div className="mt-1 flex flex-wrap gap-3 text-sm text-gray-500 dark:text-gray-400 dark:text-gray-500">
             {item.planned_purchase_date && (


### PR DESCRIPTION
## 概要

PR #47 で記録されるようになった `last_scraped_at` / `scrape_status` / `scrape_error` を ItemCard の UI に表示し、「価格がいつ更新されたか」「更新に失敗し続けているか」をユーザーが認識できるようにする。Issue #33 の最終ピース。

## 変更内容

- `src/components/ItemCard.tsx`
  - 価格表示の直下に控えめなステータス行（text-xs、グレー系）を追加
  - **経過時間表示**: `last_scraped_at` がある場合、「価格更新: ◯分前/◯時間前/◯日前」を Clock アイコン付きで表示。相対時間は date-fns の `formatDistanceToNow` + `ja` ロケール（既存 PriceChart と同じ流儀）。span の `title` にローカル時刻の絶対日時も表示
  - **失敗警告**: `scrape_status === 'failed'` の場合、AlertTriangle アイコン + 「価格を更新できていません」をアンバー色で表示（色だけに依存せず文言+アイコン）。`scrape_error` があれば `title` 属性で詳細を確認可能
  - `last_scraped_at` / `scrape_status` が無いアイテム（手動登録・未スクレイプ）は従来表示のまま
  - ダークモード対応（`dark:text-gray-500` / `dark:text-amber-400`）

## タイムゾーン処理

`last_scraped_at` は SQLite の `datetime('now')` 形式（UTC、`YYYY-MM-DD HH:MM:SS`、タイムゾーン指定なし）。そのまま `new Date()` に渡すとローカル時刻と解釈され JST 環境で 9 時間ずれるため、`parseUtcDateTime()` でオフセットが無い場合のみ末尾に `Z` を付与して UTC としてパースする。ISO 形式（`Z` やオフセット付き）はそのまま解釈し、不正な値は `null`（非表示）にフォールバック。

## 動作確認

- `npx tsc --noEmit` パス
- `npm run build` パス
- 相対時間ロジックのワンオフ検証（Asia/Tokyo 環境）: UTC 文字列の 5分前/3時間前/2日前 → 「5分前」「約3時間前」「2日前」、ISO Z付き → 「10分前」、不正値 → null（非表示）を確認
- dev サーバ起動でトップページ HTTP 200 / タイトル表示を確認（確認後に停止済み）

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)