### PR TITLE
fix: 定期価格チェックからゴミ箱アイテムを除外

### DIFF
--- a/scripts/check-prices.ts
+++ b/scripts/check-prices.ts
@@ -28,11 +28,11 @@ interface UserSettings {
 async function checkPrices() {
   console.log(`[${new Date().toISOString()}] Starting price check...`);
 
-  // 未購入のアイテムを全て取得
+  // 未購入かつゴミ箱（論理削除）に入っていないアイテムを全て取得
   const items = db.prepare(`
     SELECT id, user_id, name, url, image_url, current_price, target_price
     FROM items
-    WHERE is_purchased = 0
+    WHERE is_purchased = 0 AND deleted_at IS NULL
   `).all() as Item[];
 
   console.log(`Found ${items.length} items to check`);


### PR DESCRIPTION
## バグ

`scripts/check-prices.ts` の対象アイテム SELECT が `WHERE is_purchased = 0` のみで、`deleted_at IS NULL` の条件がなかった。そのため、ゴミ箱（論理削除）に入れた商品も6時間ごとの定期チェックで毎回スクレイプされ（1件あたり5秒待機のため周回時間も浪費）、価格更新・price_history への追記・値下げ通知まで発火していた。items API 等は論理削除を除外済みで、cron スクリプトだけが取り残されていた。

## 修正

対象アイテムの SELECT に `AND deleted_at IS NULL` を追加（最小修正）。

```sql
SELECT id, user_id, name, url, image_url, current_price, target_price
FROM items
WHERE is_purchased = 0 AND deleted_at IS NULL
```

## 動作確認

- `npx tsc --noEmit` パス
- ワンオフ確認（コミットには含めない）: worktree 内 `data/` に `getDb()` でテスト DB を初期化し、通常アイテム1件 + 論理削除アイテム1件（`deleted_at` セット）を投入。check-prices.ts と同一の SELECT を実行した結果は `['Active Item']` の1件のみで、論理削除アイテムは含まれないことを確認（確認後テスト DB は削除済み）
- 実 EC サイトへのアクセスは行っていない（SELECT の検証のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)