### PR TITLE
fix: 通知Webhook URLをホスト許可リストで検証しSSRFを防ぐ

### DIFF
--- a/src/app/api/notification-settings/route.ts
+++ b/src/app/api/notification-settings/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/db';
 import { getCurrentUser } from '@/lib/auth';
+import { isAllowedWebhookUrl } from '@/lib/url-validator';
 import { UserNotificationSettings } from '@/types';
 
 export async function GET() {
@@ -35,6 +36,21 @@ export async function PUT(request: NextRequest) {
 
   const body = await request.json();
   const { slack_webhook, discord_webhook, notify_on_price_drop, notify_on_target_price } = body;
+
+  // Webhook URLの検証（SSRF対策）
+  // 非空の場合のみ検証。空文字/null/undefinedは「未設定」として許可（通知は送られないだけ）。
+  if (slack_webhook && !isAllowedWebhookUrl(slack_webhook, 'slack')) {
+    return NextResponse.json(
+      { error: 'Slack Webhook URL が不正です。https://hooks.slack.com/... の形式で入力してください' },
+      { status: 400 }
+    );
+  }
+  if (discord_webhook && !isAllowedWebhookUrl(discord_webhook, 'discord')) {
+    return NextResponse.json(
+      { error: 'Discord Webhook URL が不正です。https://discord.com/api/webhooks/... の形式で入力してください' },
+      { status: 400 }
+    );
+  }
 
   const db = getDb();
 

--- a/src/lib/notifier.ts
+++ b/src/lib/notifier.ts
@@ -1,4 +1,5 @@
 import { Item } from '@/types';
+import { isAllowedWebhookUrl } from '@/lib/url-validator';
 
 export interface NotificationPayload {
   item: Item;
@@ -12,13 +13,20 @@ export async function sendSlackNotification(
   webhookUrl: string,
   payload: NotificationPayload
 ): Promise<boolean> {
+  // 送信前検証（多重防御 / SSRF対策）
+  // PUT検証前に保存された不正URLや別経路で混入した不正URLにもfetchしない。
+  if (!isAllowedWebhookUrl(webhookUrl, 'slack')) {
+    console.warn('Slack notification skipped: disallowed webhook host');
+    return false;
+  }
+
   const { item, oldPrice, newPrice, targetPrice, type } = payload;
-  
+
   const emoji = type === 'target_reached' ? '🎉' : '📉';
-  const title = type === 'target_reached' 
+  const title = type === 'target_reached'
     ? `${emoji} 目標価格に到達！`
     : `${emoji} 価格が下がりました！`;
-  
+
   const priceChange = oldPrice - newPrice;
   const changePercent = Math.round((priceChange / oldPrice) * 100);
 
@@ -73,13 +81,20 @@ export async function sendDiscordNotification(
   webhookUrl: string,
   payload: NotificationPayload
 ): Promise<boolean> {
+  // 送信前検証（多重防御 / SSRF対策）
+  // PUT検証前に保存された不正URLや別経路で混入した不正URLにもfetchしない。
+  if (!isAllowedWebhookUrl(webhookUrl, 'discord')) {
+    console.warn('Discord notification skipped: disallowed webhook host');
+    return false;
+  }
+
   const { item, oldPrice, newPrice, targetPrice, type } = payload;
-  
+
   const emoji = type === 'target_reached' ? '🎉' : '📉';
-  const title = type === 'target_reached' 
+  const title = type === 'target_reached'
     ? `${emoji} 目標価格に到達！`
     : `${emoji} 価格が下がりました！`;
-  
+
   const priceChange = oldPrice - newPrice;
   const changePercent = Math.round((priceChange / oldPrice) * 100);
 

--- a/src/lib/url-validator.ts
+++ b/src/lib/url-validator.ts
@@ -97,6 +97,45 @@ export function getSourceFromUrl(urlString: string): SourceType {
   return result.source;
 }
 
+// 通知Webhookの許可ホスト（完全一致）
+// SSRF対策: クラウドメタデータ(169.254.169.254)や内部宛URLを登録・送信できないようにする
+const ALLOWED_SLACK_WEBHOOK_HOSTS = ['hooks.slack.com'] as const;
+const ALLOWED_DISCORD_WEBHOOK_HOSTS = ['discord.com', 'discordapp.com'] as const;
+
+type WebhookType = 'slack' | 'discord';
+
+/**
+ * 通知Webhook URLが許可されているかを検証（SSRF対策）
+ * - URLとしてパース可能であること
+ * - プロトコルがhttps（httpは不可）
+ * - ホスト名が種別ごとの許可リストに完全一致
+ *   - slack: hooks.slack.com
+ *   - discord: discord.com / discordapp.com
+ *
+ * 完全一致のため `hooks.slack.com.evil.com` のようなサブドメイン偽装は拒否される。
+ * 空文字/null/undefinedは「未設定」とみなし、ここでは検証対象外（呼び出し側で扱う）。
+ */
+export function isAllowedWebhookUrl(urlString: string, type: WebhookType): boolean {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(urlString);
+  } catch {
+    return false;
+  }
+
+  // HTTPSのみ許可（httpは不可）
+  if (parsedUrl.protocol !== 'https:') {
+    return false;
+  }
+
+  const hostname = parsedUrl.hostname.toLowerCase();
+  const allowedHosts =
+    type === 'slack' ? ALLOWED_SLACK_WEBHOOK_HOSTS : ALLOWED_DISCORD_WEBHOOK_HOSTS;
+
+  // ホスト名の完全一致チェック
+  return allowedHosts.some((host) => hostname === host);
+}
+
 /**
  * 一般的なURLをサニタイズ（任意のドメイン）
  * 許可リストに関係なく、URLを正規化


### PR DESCRIPTION
## 脆弱性（reviewer 監査で発見・高深刻度）

`src/app/api/notification-settings/route.ts` の PUT が `slack_webhook` / `discord_webhook` を**一切検証せず**保存し、`scripts/check-prices.ts`（サーバ上の cron）が `src/lib/notifier.ts` でその URL に無条件 POST していた。

このため `http://169.254.169.254/...`（クラウドメタデータ）や `http://localhost:8000/api/...` など内部宛 URL を登録でき、**サーバを踏み台にした SSRF が定期実行**される状態だった（cron 起点 SSRF）。

## 修正方針：https 必須 + ホスト許可リスト（完全一致）

`src/lib/url-validator.ts` に webhook 専用の検証関数 `isAllowedWebhookUrl(url, type)` を追加。

- URL としてパース可能であること
- **プロトコルが https**（http 不可）
- ホスト名が種別ごとの許可リストに**完全一致**
  - slack: `hooks.slack.com`
  - discord: `discord.com` / `discordapp.com`
- 完全一致のため `hooks.slack.com.evil.com` のようなサブドメイン偽装も拒否
- 空文字 / null は「未設定」として扱い、検証スキップ（保存は許可。通知が送られないだけ）

## 2 段階の防御（多重防御）

1. **PUT 側**（`notification-settings/route.ts`）: `slack_webhook` / `discord_webhook` が**非空**の場合に検証し、許可外は **400** を返す
   - 例: `Slack Webhook URL が不正です。https://hooks.slack.com/... の形式で入力してください`
   - 空 / null はそのまま保存可
2. **notifier 側**（`notifier.ts`）: `sendSlackNotification` / `sendDiscordNotification` の**送信直前**に同じ検証を行い、許可外 URL には fetch せず `false` を返す（警告ログ出力）
   - PUT 検証を追加する**前に保存された不正 URL**や、将来別経路で混入した不正 URL からも守る

## 動作確認

- `npx tsc --noEmit` パス
- `npm run build` パス
- `npx eslint`（対象3ファイル）エラーなし
- 検証関数の単体テスト（全 15 ケース通過）:
  - **拒否**: `http://hooks.slack.com/...`（http）, `https://169.254.169.254/...`, `http://localhost:8000/...`, `https://localhost/...`, `https://evil.com/...`, `https://hooks.slack.com.evil.com/...`（サブドメイン偽装）, slack 欄に discord URL / discord 欄に slack URL, 空文字
  - **許可**: `https://hooks.slack.com/services/xxx/yyy/zzz`, `https://discord.com/api/webhooks/xxx/yyy`, `https://discordapp.com/api/webhooks/...`
  - 空文字 / null は PUT 側の非空ガードで検証スキップ → 「未設定」として保存可
- 実際の Slack / Discord への送信は行っていない（検証は関数単体）

## 変更ファイル

- `src/lib/url-validator.ts`: `isAllowedWebhookUrl(url, type)` 追加
- `src/app/api/notification-settings/route.ts`: PUT で非空 webhook を検証、許可外は 400
- `src/lib/notifier.ts`: 送信直前に検証、許可外は fetch せず false

🤖 Generated with [Claude Code](https://claude.com/claude-code)