### PR TITLE
fix: scrapeUrl例外時もscrape_status='failed'を記録 (#33 follow-up)

### DIFF
--- a/scripts/check-prices.ts
+++ b/scripts/check-prices.ts
@@ -127,6 +127,20 @@ async function checkPrices() {
 
     } catch (error) {
       console.error(`  - Error: ${error}`);
+      // 例外発生時も last_scraped_at と失敗ステータスを記録する。
+      // この記録用UPDATE自体が失敗してもループ全体は止めない。
+      try {
+        const message = (error instanceof Error ? error.message : String(error)).slice(0, 500);
+        db.prepare(`
+          UPDATE items
+          SET last_scraped_at = datetime('now'),
+              scrape_status = 'failed',
+              scrape_error = ?
+          WHERE id = ?
+        `).run(message, item.id);
+      } catch (updateError) {
+        console.error(`  - Failed to record scrape failure: ${updateError}`);
+      }
     } finally {
       // レートリミット対策で5秒待機（スキップ・エラー時も含め全アイテム間に適用）
       await new Promise(resolve => setTimeout(resolve, 5000));

--- a/scripts/check-prices.ts
+++ b/scripts/check-prices.ts
@@ -38,6 +38,10 @@ async function checkPrices() {
   console.log(`Found ${items.length} items to check`);
 
   for (const item of items) {
+    // スクレイプ結果の記録（成功側UPDATE）が完了したかどうか。
+    // 完了後に後続処理（price_history INSERTや通知）が throw しても、
+    // catch 側で scrape_status='failed' に上書きしないようにする。
+    let statusRecorded = false;
     try {
       console.log(`Checking: ${item.name.substring(0, 50)}...`);
       
@@ -72,6 +76,7 @@ async function checkPrices() {
             updated_at = datetime('now')
         WHERE id = ?
       `).run(newPrice, outcome.status, outcome.error, item.id);
+      statusRecorded = true;
 
       // 価格履歴に追加
       db.prepare(`
@@ -128,18 +133,22 @@ async function checkPrices() {
     } catch (error) {
       console.error(`  - Error: ${error}`);
       // 例外発生時も last_scraped_at と失敗ステータスを記録する。
+      // ただし成功記録済み（statusRecorded=true）の場合は、後続処理の例外で
+      // scrape_status='failed' に上書きしない。
       // この記録用UPDATE自体が失敗してもループ全体は止めない。
-      try {
-        const message = (error instanceof Error ? error.message : String(error)).slice(0, 500);
-        db.prepare(`
-          UPDATE items
-          SET last_scraped_at = datetime('now'),
-              scrape_status = 'failed',
-              scrape_error = ?
-          WHERE id = ?
-        `).run(message, item.id);
-      } catch (updateError) {
-        console.error(`  - Failed to record scrape failure: ${updateError}`);
+      if (!statusRecorded) {
+        try {
+          const message = (error instanceof Error ? error.message : String(error)).slice(0, 500);
+          db.prepare(`
+            UPDATE items
+            SET last_scraped_at = datetime('now'),
+                scrape_status = 'failed',
+                scrape_error = ?
+            WHERE id = ?
+          `).run(message, item.id);
+        } catch (updateError) {
+          console.error(`  - Failed to record scrape failure: ${updateError}`);
+        }
       }
     } finally {
       // レートリミット対策で5秒待機（スキップ・エラー時も含め全アイテム間に適用）

--- a/src/app/api/items/[id]/refresh/route.ts
+++ b/src/app/api/items/[id]/refresh/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb } from '@/lib/db';
-import { scrapeUrl, deriveScrapeOutcome } from '@/lib/scraper';
+import { scrapeUrl, deriveScrapeOutcome, ScrapedItem } from '@/lib/scraper';
 import { getCurrentUser } from '@/lib/auth';
 
 interface DbItem {
@@ -26,8 +26,26 @@ export async function POST(
     return NextResponse.json({ error: 'Item not found' }, { status: 404 });
   }
 
-  // 再スクレイピング
-  const scraped = await scrapeUrl(item.url);
+  // 再スクレイピング（例外時も last_scraped_at と失敗ステータスを記録する）
+  let scraped: ScrapedItem;
+  try {
+    scraped = await scrapeUrl(item.url);
+  } catch (error) {
+    const message = (error instanceof Error ? error.message : String(error)).slice(0, 500);
+    try {
+      db.prepare(`
+        UPDATE items
+        SET last_scraped_at = datetime('now'),
+            scrape_status = 'failed',
+            scrape_error = ?
+        WHERE id = ?
+      `).run(message, item.id);
+    } catch (updateError) {
+      // 記録用UPDATEの失敗ではレスポンス自体は変えない
+      console.error('Failed to record scrape failure:', updateError);
+    }
+    return NextResponse.json({ error: '価格の再取得に失敗しました' }, { status: 500 });
+  }
 
   // スクレイプ結果（成功/失敗）を導出（check-prices と共通ロジック）
   const outcome = deriveScrapeOutcome(scraped);


### PR DESCRIPTION
## 概要

#33 のフォローアップ。check-prices スクリプトの例外catchパスで、scrapeUrl が例外を投げたアイテムに scrape_status / last_scraped_at / scrape_error が記録されない漏れを修正する。

PR #47 で導入された記録処理は、正常リターンで価格が取れなかったケース（`scraped.price` が null）では `deriveScrapeOutcome` 経由で 'failed' を記録するが、`scrapeUrl` 自体が throw した場合は catch でログ出力のみだった。

## 受け入れ条件

- scrapeUrl が例外を投げたアイテムでも last_scraped_at と scrape_status='failed' が記録される

## 変更内容

### scripts/check-prices.ts
- 例外catchパスで last_scraped_at（現在時刻）、scrape_status='failed'、scrape_error（例外メッセージ、500文字に切り詰め）を記録
- 記録用UPDATE自体の失敗は内側の try/catch で握り、ループ全体を止めない（既存のエラーハンドリング方針に準拠）
- 成功時の更新・通知・finally のアイテム間待機・ゴミ箱除外などの既存挙動は変更なし

### src/app/api/items/[id]/refresh/route.ts
- 同じ漏れを確認したため修正。scrapeUrl が throw すると記録処理に到達せず Next.js の汎用500で終わっていたが、try/catch で失敗ステータスを記録した上で 500 の JSON エラーを返すように変更
- scrapeUrl は内部でほぼ全ての失敗を catch して price:null を返す設計のため、この catch パスに入るのは想定外例外のみ。レスポンス変化は「汎用500 → JSONエラーの500」に留まる

## 確認

- `npx tsc --noEmit` パス
- `npm run build` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)