### PR TITLE
feat(budget): 価格未取得アイテムが合計に含まれない旨の注記を表示

### DIFF
--- a/src/components/BudgetView.tsx
+++ b/src/components/BudgetView.tsx
@@ -79,6 +79,10 @@ export default function BudgetView() {
     .filter(item => selectedIds.has(item.id))
     .reduce((sum, item) => sum + (item.current_price || 0) * (item.quantity || 1), 0);
 
+  // 価格未取得（null/0）のアイテム件数。合計計算では 0 扱いになるため注記用にカウントする
+  const countNoPriceItems = (items: Item[]) => items.filter(item => !item.current_price).length;
+  const totalNoPriceCount = countNoPriceItems(allItems);
+
   return (
     <div className="space-y-4">
       {/* 合計カード */}
@@ -90,6 +94,11 @@ export default function BudgetView() {
           </div>
           <div className="text-3xl font-bold">¥{totalBudget.toLocaleString()}</div>
           <div className="text-sm opacity-75 mt-1">{allItems.length}件</div>
+          {totalNoPriceCount > 0 && (
+            <div className="text-xs opacity-75 mt-1">
+              うち{totalNoPriceCount}件は価格未取得のため合計に含まれません
+            </div>
+          )}
         </div>
         
         <div className={`rounded-lg p-4 transition-all ${
@@ -137,6 +146,7 @@ export default function BudgetView() {
             const monthIds = data.items.map(i => i.id);
             const allMonthSelected = monthIds.every(id => selectedIds.has(id));
             const someMonthSelected = monthIds.some(id => selectedIds.has(id));
+            const monthNoPriceCount = countNoPriceItems(data.items);
 
             return (
               <div key={month} className="bg-white dark:bg-slate-800 rounded-lg shadow p-4">
@@ -157,6 +167,11 @@ export default function BudgetView() {
                     ¥{data.total.toLocaleString()}
                   </span>
                 </div>
+                {monthNoPriceCount > 0 && (
+                  <div className="text-xs text-gray-500 dark:text-gray-400 text-right -mt-2 mb-2">
+                    うち{monthNoPriceCount}件は価格未取得のため合計に含まれません
+                  </div>
+                )}
                 <div className="space-y-1">
                   {data.items.map((item) => {
                     const isSelected = selectedIds.has(item.id);
@@ -212,6 +227,11 @@ export default function BudgetView() {
                   ¥{undatedData.total.toLocaleString()}
                 </span>
               </div>
+              {countNoPriceItems(undatedData.items) > 0 && (
+                <div className="text-xs text-gray-500 dark:text-gray-400 text-right -mt-2 mb-2">
+                  うち{countNoPriceItems(undatedData.items)}件は価格未取得のため合計に含まれません
+                </div>
+              )}
               <div className="space-y-1">
                 {undatedData.items.map((item) => {
                   const isSelected = selectedIds.has(item.id);


### PR DESCRIPTION
## 概要
BudgetView で `current_price` が null/0 のアイテムは合計計算時に 0 扱いとなり、黙って合計から除外されていた。この点をユーザーに明示する注記を追加する。

## 受け入れ条件
- [x] 月カード/全体合計に価格未取得アイテムが含まれる場合「うちN件は価格未取得のため合計に含まれません」の注記を表示
- [x] 該当0件なら非表示
- [x] 既存の合計表示・選択合計の挙動は維持（計算ロジックは一切変更なし）

## 変更内容
- `src/components/BudgetView.tsx`
  - `countNoPriceItems` ヘルパーを追加（`!item.current_price` で判定。アイテム行の `---` 表示や合計計算の `|| 0` と同じ null/0 同一視の基準）
  - 全体合計カード: 件数表示の下に注記（白文字グラデ背景に合わせ `text-xs opacity-75`）
  - 各月カード: 合計表示の直下に右寄せで注記（`text-xs text-gray-500 dark:text-gray-400`）
  - 購入時期未定カード: 同様の注記（同じ問題が存在するため）

## 実装上の判断
- 件数算出はフロント側で実施。`/api/budget` は月別のアイテム配列をそのまま返しており、フロントで件数を導出できるため API 変更は不要と判断

## 確認
- `npx tsc --noEmit` pass
- `npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)