### PR TITLE
fix(notifier): webhook fetchに10秒タイムアウトを追加

### DIFF
--- a/src/lib/notifier.ts
+++ b/src/lib/notifier.ts
@@ -1,6 +1,17 @@
 import { Item } from '@/types';
 import { isAllowedWebhookUrl } from '@/lib/url-validator';
 
+// Webhook送信のタイムアウト（ミリ秒）。
+// 応答しないエンドポイントでcheck-pricesのループが停止しないようにする。
+const WEBHOOK_TIMEOUT_MS = 10_000;
+
+// タイムアウト起因の例外かどうかを判定する。
+// AbortSignal.timeout()はTimeoutError、abort()経由はAbortErrorを投げる。
+function isTimeoutError(error: unknown): boolean {
+  return error instanceof Error &&
+    (error.name === 'TimeoutError' || error.name === 'AbortError');
+}
+
 export interface NotificationPayload {
   item: Item;
   oldPrice: number;
@@ -69,10 +80,16 @@ export async function sendSlackNotification(
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(message),
+      // 応答しないエンドポイントで処理が止まらないようタイムアウトを設定
+      signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),
     });
     return res.ok;
   } catch (error) {
-    console.error('Slack notification failed:', error);
+    if (isTimeoutError(error)) {
+      console.error(`Slack notification timed out after ${WEBHOOK_TIMEOUT_MS}ms`);
+    } else {
+      console.error('Slack notification failed:', error);
+    }
     return false;
   }
 }
@@ -137,10 +154,16 @@ export async function sendDiscordNotification(
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ embeds: [embed] }),
+      // 応答しないエンドポイントで処理が止まらないようタイムアウトを設定
+      signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),
     });
     return res.ok;
   } catch (error) {
-    console.error('Discord notification failed:', error);
+    if (isTimeoutError(error)) {
+      console.error(`Discord notification timed out after ${WEBHOOK_TIMEOUT_MS}ms`);
+    } else {
+      console.error('Discord notification failed:', error);
+    }
     return false;
   }
 }


### PR DESCRIPTION
## 概要

Slack/Discord 通知の webhook fetch にタイムアウトがなく、応答しないエンドポイント宛だと fetch が無期限にハングし、check-prices のループ全体が停止する問題を修正する。

## 受け入れ条件

- Slack/Discord 通知 fetch に `AbortSignal.timeout(約10秒)` が付与されている
- 応答しないエンドポイント宛の通知が約10秒で `false` 返却となり、check-prices のループが継続する

## 変更内容

- `src/lib/notifier.ts`
  - `WEBHOOK_TIMEOUT_MS = 10_000` 定数を追加
  - `sendSlackNotification` / `sendDiscordNotification` の fetch に `signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS)` を付与
  - タイムアウト判定ヘルパー `isTimeoutError`（`TimeoutError` / `AbortError`）を追加し、タイムアウト時はそれと分かるログを出力
  - タイムアウト例外は既存の try/catch で捕捉され `false` を返す（throw は外に漏れない）
  - 成功時 `true` / 失敗時 `false` / SSRF 検証（PR #57 の `isAllowedWebhookUrl`）は変更なし

## 検証

- `npx tsc --noEmit`: pass
- `npm run build`: pass
- Node で無応答サーバ宛 fetch + `AbortSignal.timeout` の挙動を確認: 指定時間後に `TimeoutError`（`instanceof Error` が true）が投げられ、catch で捕捉されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)