### PR TITLE
feat: フィルタ/検索0件時の空状態メッセージと条件クリアボタン

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -291,6 +291,9 @@ export default function Home() {
     setSelectedPriority(null);
     setSelectedGroup(null);
     setSortBy('priority');
+    // 選択モードを解除（クリア後に見えないアイテムへの一括操作を防ぐ）
+    setSelectionMode(false);
+    setSelectedItems(new Set());
   };
 
   // フィルター適用（カテゴリ、検索、優先度、比較グループ）

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -284,6 +284,15 @@ export default function Home() {
     touchEventOptions: { passive: false },
   });
 
+  // フィルター・検索・並び順をすべて初期値に戻す
+  const clearFilters = () => {
+    setSearchQuery('');
+    setSelectedCategory(null);
+    setSelectedPriority(null);
+    setSelectedGroup(null);
+    setSortBy('priority');
+  };
+
   // フィルター適用（カテゴリ、検索、優先度、比較グループ）
   const filteredItems = items
     .filter(item => {
@@ -666,6 +675,18 @@ export default function Home() {
             ) : items.length === 0 ? (
               <div className="text-center py-12 text-slate-500 dark:text-slate-400">
                 まだアイテムがありません。上のフォームから追加してください。
+              </div>
+            ) : filteredItems.length === 0 ? (
+              /* アイテムはあるがフィルター/検索の結果が0件の場合 */
+              <div className="text-center py-12 text-slate-500 dark:text-slate-400">
+                <p>条件に一致するアイテムがありません</p>
+                <button
+                  onClick={clearFilters}
+                  className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 text-sm text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 rounded-lg transition-colors"
+                >
+                  <X size={16} />
+                  条件をクリア
+                </button>
               </div>
             ) : (
               <DndContext


### PR DESCRIPTION
## 概要

リストタブでアイテム自体は存在するのに、フィルタ/検索の適用結果が0件になった場合、これまで何も表示されず空白になっていた。専用の空状態メッセージと「条件をクリア」ボタンを追加する。

## 受け入れ条件

- アイテムは存在するがフィルタ/検索0件のとき「条件に一致するアイテムがありません」を表示
- 「条件をクリア」ボタンで検索語・カテゴリ・優先度・グループ・並び順が初期化され全件再表示

## 変更内容

- `src/app/page.tsx`
  - `clearFilters` 関数を追加。以下の5つのフィルタ state を初期値に戻す
    - `searchQuery` → `''`
    - `selectedCategory` → `null`
    - `selectedPriority` → `null`
    - `selectedGroup` → `null`
    - `sortBy` → `'priority'`（コード上のデフォルト値）
  - リスト描画の分岐に `items.length > 0 && filteredItems.length === 0` 時のブランチを追加し、メッセージと「条件をクリア」ボタンを表示
  - アイテムが本当に0件のときの既存メッセージ「まだアイテムがありません。上のフォームから追加してください。」は変更なし
  - スタイルは既存空状態（`text-center py-12 text-slate-500 dark:text-slate-400`）と既存ボタンパターンに準拠

## 確認

- `npx tsc --noEmit` パス
- `npm run build` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)