### PR TITLE
feat(trash): ゴミ箱を空にする DELETE /api/trash を実装

### DIFF
--- a/src/app/api/trash/route.ts
+++ b/src/app/api/trash/route.ts
@@ -33,3 +33,22 @@ export async function GET() {
 
   return NextResponse.json(items);
 }
+
+// ゴミ箱を空にする（自ユーザーのゴミ箱内アイテムを全件ハード削除）
+export async function DELETE() {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
+
+  const db = getDb();
+
+  // user_id を必ず条件に含め、他ユーザーのアイテムには触れない
+  // 削除パターンは trash/[id] の個別完全削除（items のみ DELETE）と整合
+  const result = db.prepare(`
+    DELETE FROM items
+    WHERE user_id = ? AND deleted_at IS NOT NULL
+  `).run(user.id);
+
+  return NextResponse.json({ success: true, deleted: result.changes });
+}


### PR DESCRIPTION
## 概要
TrashView の「ゴミ箱を空にする」ボタンが `DELETE /api/trash` を呼ぶがハンドラ不在で 405 になっていた問題を修正。`src/app/api/trash/route.ts` に DELETE ハンドラを追加した。

## 受け入れ条件
- [x] DELETE /api/trash が認証ユーザーの `deleted_at IS NOT NULL` アイテムを全件ハード削除し件数を返す（`{ success: true, deleted: <件数> }`）
- [x] 未認証は 401（既存ルートと同じ `getCurrentUser()` ヘルパーを使用）
- [x] WHERE 句に `user_id = ?` を含め、他ユーザーのアイテムは削除されない
- [x] TrashView のボタン押下で一覧が空になる（フロント側は既存実装のまま動作）

## 実装メモ
- 削除パターンは既存の `trash/[id]` DELETE（個別完全削除）と同じく **items テーブルのみの DELETE**。既存の個別削除・7日自動パージも関連行（price_history 等）は消していないため、それに整合させた。孤児行の一括対応は別タスクで全削除経路をまとめて行う予定。
- TrashView 側は `res.ok` を見ていないが、削除後に `fetchItems()` で再取得するため最低限の動作は問題なし（フロント修正はスコープ外）。

## 確認
- `npx tsc --noEmit` パス
- `npm run build` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)