### PR TITLE
fix(check-prices): 価格不変時は price_history に INSERT しない

### DIFF
--- a/scripts/check-prices.ts
+++ b/scripts/check-prices.ts
@@ -78,11 +78,23 @@ async function checkPrices() {
       `).run(newPrice, outcome.status, outcome.error, item.id);
       statusRecorded = true;
 
-      // 価格履歴に追加
-      db.prepare(`
-        INSERT INTO price_history (item_id, price)
-        VALUES (?, ?)
-      `).run(item.id, newPrice);
+      // 価格履歴に追加（直近履歴と同値ならスキップ）。
+      // 同一価格で毎回 INSERT すると /api/items の previous_price（2番目に新しい履歴）が
+      // 常に現在価格と同値になり、値下がり表示が機能しなくなるため。
+      // 履歴が無い初回、または直近履歴と価格が異なる場合のみ追加する。
+      const lastHistory = db.prepare(`
+        SELECT price FROM price_history
+        WHERE item_id = ?
+        ORDER BY recorded_at DESC, id DESC
+        LIMIT 1
+      `).get(item.id) as { price: number } | undefined;
+
+      if (!lastHistory || lastHistory.price !== newPrice) {
+        db.prepare(`
+          INSERT INTO price_history (item_id, price)
+          VALUES (?, ?)
+        `).run(item.id, newPrice);
+      }
 
       console.log(`  - Price: ¥${oldPrice?.toLocaleString() || '---'} -> ¥${newPrice.toLocaleString()}`);
 


### PR DESCRIPTION
## 概要

check-prices（scripts/check-prices.ts）はスクレイプ成功のたび無条件で price_history に INSERT していたため、定期実行2回目以降は /api/items の previous_price（2番目に新しい履歴）が常に現在価格と同値になり、UIの値下がり表示が事実上無効化されていた。

INSERT 前に当該アイテムの直近 price_history（ORDER BY recorded_at DESC, id DESC LIMIT 1）を取得し、新価格と同値なら INSERT をスキップするように変更。refresh API（items/[id]/refresh）・items PATCH の「価格が変わった時のみ履歴追加」と挙動を揃える。

## 受け入れ条件

- 同一価格で2回実行しても price_history が増えない（直近履歴と同値ならスキップ）
- 価格変動時は従来どおり1行追加（履歴が無い初回も INSERT）
- current_price / scrape_status / last_scraped_at の更新は価格不変でも従来どおり

## 実装上の判断

- 比較基準は「直近の price_history 行の price」を採用。refresh route は item.current_price と比較しているが、current_price 比較だと「current_price は設定済みだが履歴が1件も無い」ケースで初回履歴が永久に作られない。直近履歴比較なら「履歴が無い初回は INSERT」「直近履歴と同値ならスキップ」を仕様どおり満たし、実効的な結果は refresh route と整合する
- 通知（値下がり/目標価格到達）判定は oldPrice = items.current_price（SELECT 時点の値）と newPrice の比較であり price_history に依存しないため、影響なし
- statusRecorded フラグ、5秒待機、失敗時の記録などの既存挙動は変更なし

## 検証

- `npx tsc --noEmit` パス
- `npm run build` パス
- 一時 SQLite DB でのスモークテスト: 同値連続実行でスキップ、変動時 INSERT、価格が元に戻った場合も INSERT、別アイテムは独立、を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)