### PR TITLE
fix: 論理削除除外漏れの一掃（purchased / export / categories item_count）

### DIFF
--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -12,7 +12,7 @@ export async function GET() {
   const categories = db.prepare(`
     SELECT c.*, COUNT(i.id) as item_count
     FROM categories c
-    LEFT JOIN items i ON c.id = i.category_id AND i.is_purchased = 0 AND i.deleted_at IS NULL
+    LEFT JOIN items i ON c.id = i.category_id AND i.user_id = c.user_id AND i.is_purchased = 0 AND i.deleted_at IS NULL
     WHERE c.user_id = ?
     GROUP BY c.id
     ORDER BY c.sort_order ASC, c.name ASC

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -12,7 +12,7 @@ export async function GET() {
   const categories = db.prepare(`
     SELECT c.*, COUNT(i.id) as item_count
     FROM categories c
-    LEFT JOIN items i ON c.id = i.category_id AND i.is_purchased = 0
+    LEFT JOIN items i ON c.id = i.category_id AND i.is_purchased = 0 AND i.deleted_at IS NULL
     WHERE c.user_id = ?
     GROUP BY c.id
     ORDER BY c.sort_order ASC, c.name ASC

--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -28,7 +28,8 @@ export async function GET(request: NextRequest) {
 
   const db = getDb();
 
-  let whereClause = 'WHERE i.user_id = ?';
+  // ゴミ箱（論理削除済み）のアイテムはエクスポート対象から除外する
+  let whereClause = 'WHERE i.user_id = ? AND i.deleted_at IS NULL';
   if (filter === 'wishlist') {
     whereClause += ' AND i.is_purchased = 0';
   } else if (filter === 'purchased') {

--- a/src/app/api/purchased/route.ts
+++ b/src/app/api/purchased/route.ts
@@ -18,7 +18,7 @@ export async function GET() {
       cat.color as category_color
     FROM items i
     LEFT JOIN categories cat ON i.category_id = cat.id
-    WHERE i.is_purchased = 1 AND i.user_id = ?
+    WHERE i.is_purchased = 1 AND i.user_id = ? AND i.deleted_at IS NULL
     ORDER BY i.purchased_at DESC
   `).all(user.id);
 
@@ -29,7 +29,7 @@ export async function GET() {
       COUNT(*) as count,
       SUM(current_price) as total
     FROM items
-    WHERE is_purchased = 1 AND user_id = ? AND purchased_at IS NOT NULL
+    WHERE is_purchased = 1 AND user_id = ? AND purchased_at IS NOT NULL AND deleted_at IS NULL
     GROUP BY strftime('%Y-%m', purchased_at)
     ORDER BY month DESC
     LIMIT 12
@@ -41,7 +41,7 @@ export async function GET() {
       COUNT(*) as count,
       SUM(current_price) as total
     FROM items
-    WHERE is_purchased = 1 AND user_id = ?
+    WHERE is_purchased = 1 AND user_id = ? AND deleted_at IS NULL
   `).get(user.id) as { count: number; total: number | null };
 
   return NextResponse.json({


### PR DESCRIPTION
## 概要
reviewer 監査で検出された論理削除（ゴミ箱）除外漏れを 3 ファイルで修正。stats（PR #54）・comparison-groups（PR #60）と同じ方針（クエリへの条件追加のみ）。

## 変更内容
- `src/app/api/purchased/route.ts`: 一覧・月別集計（monthlySummary）・累計（totalStats）の 3 クエリすべてに `AND deleted_at IS NULL` を追加
- `src/app/api/export/route.ts`: WHERE 句の基底を `WHERE i.user_id = ? AND i.deleted_at IS NULL` に変更。filter パラメータの全分岐（all / wishlist / purchased）でゴミ箱除外が効く
- `src/app/api/categories/route.ts`: item_count 集計の JOIN ON 句に `AND i.deleted_at IS NULL` を追加

## 受け入れ条件
- 購入済みアイテムの論理削除後、GET /api/purchased の items / monthlySummary / totalStats に含まれない
- GET /api/export の CSV にゴミ箱アイテムが含まれない（全 filter 分岐）
- GET /api/categories の item_count がゴミ箱除外（復元で +1 に戻る）

## 検証
- `npx tsc --noEmit`: pass
- `npm run build`: pass

## 追加調査（修正は本 PR の 3 ファイルに限定、以下は報告のみ）
`grep` による API ルート全体の確認で、同種の deleted_at 未考慮箇所が残存:
- 重複 URL チェック: `items/route.ts:110` / `import-wishlist/route.ts:98` / `extension-import/route.ts:62` は `deleted_at IS NULL` なし（extension-add は対応済みで不整合。ゴミ箱内アイテムと同一 URL の再登録が重複扱いになる）
- ID 指定系: `items/[id]/route.ts`（GET/PUT）、`items/[id]/refresh/route.ts`、`items/[id]/price-history/route.ts` はゴミ箱アイテムにもアクセス・更新可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)