### PR TITLE
fix: 一覧/予算/ゴミ箱の取得失敗時エラー表示と再試行（無限読み込み解消）

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,6 +29,7 @@ export default function Home() {
   const [activeTab, setActiveTab] = useState<Tab>('list');
   const [animationClass, setAnimationClass] = useState('');
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
   const [selectedGroup, setSelectedGroup] = useState<number | null>(null);
@@ -41,22 +42,52 @@ export default function Home() {
   const [selectedItems, setSelectedItems] = useState<Set<number>>(new Set());
 
   const fetchItems = async () => {
-    const res = await fetch('/api/items');
-    const data = await res.json();
-    setItems(data);
-    setLoading(false);
+    try {
+      const res = await fetch('/api/items');
+      if (!res.ok) throw new Error(`Failed to fetch items: ${res.status}`);
+      const data = await res.json();
+      // 非配列レスポンス（エラーJSON等）を配列stateに入れない
+      if (!Array.isArray(data)) throw new Error('Unexpected response format');
+      setItems(data);
+      setLoadError(false);
+    } catch (error) {
+      console.error('Failed to fetch items:', error);
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
   };
 
+  // 補助データ: 失敗しても空配列のままにしてクラッシュを防ぐ（エラーUIは出さない）
   const fetchGroups = async () => {
-    const res = await fetch('/api/comparison-groups');
-    const data = await res.json();
-    setGroups(data);
+    try {
+      const res = await fetch('/api/comparison-groups');
+      if (!res.ok) return;
+      const data = await res.json();
+      if (Array.isArray(data)) setGroups(data);
+    } catch (error) {
+      console.error('Failed to fetch comparison groups:', error);
+    }
   };
 
   const fetchCategories = async () => {
-    const res = await fetch('/api/categories');
-    const data = await res.json();
-    setCategories(data);
+    try {
+      const res = await fetch('/api/categories');
+      if (!res.ok) return;
+      const data = await res.json();
+      if (Array.isArray(data)) setCategories(data);
+    } catch (error) {
+      console.error('Failed to fetch categories:', error);
+    }
+  };
+
+  // 読み込み失敗時の再試行（補助データも併せて再取得）
+  const handleRetry = () => {
+    setLoadError(false);
+    setLoading(true);
+    fetchItems();
+    fetchGroups();
+    fetchCategories();
   };
 
   useEffect(() => {
@@ -663,6 +694,16 @@ export default function Home() {
 
             {loading ? (
               <div className="text-center py-12 text-slate-500 dark:text-slate-400">読み込み中...</div>
+            ) : loadError ? (
+              <div className="text-center py-12 text-slate-500 dark:text-slate-400">
+                <p>読み込みに失敗しました</p>
+                <button
+                  onClick={handleRetry}
+                  className="mt-3 px-4 py-2 text-sm text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 rounded-lg transition-colors"
+                >
+                  再試行
+                </button>
+              </div>
             ) : items.length === 0 ? (
               <div className="text-center py-12 text-slate-500 dark:text-slate-400">
                 まだアイテムがありません。上のフォームから追加してください。

--- a/src/components/BudgetView.tsx
+++ b/src/components/BudgetView.tsx
@@ -15,22 +15,48 @@ export default function BudgetView() {
   const [budget, setBudget] = useState<BudgetData>({});
   const [allItems, setAllItems] = useState<Item[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 
-  useEffect(() => {
-    fetch('/api/budget')
-      .then((res) => res.json())
-      .then((data) => {
-        setBudget(data);
-        // 全アイテムをフラットに
-        const items: Item[] = [];
-        Object.values(data).forEach((monthData: any) => {
+  const fetchBudget = async () => {
+    try {
+      const res = await fetch('/api/budget');
+      if (!res.ok) throw new Error(`Failed to fetch budget: ${res.status}`);
+      const data = await res.json();
+      // 月キーのオブジェクト以外（エラーJSON等）を弾く
+      if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+        throw new Error('Unexpected response format');
+      }
+      // 各エントリを検証し、不正な形のエントリは除外してクラッシュを防ぐ
+      const safeBudget: BudgetData = {};
+      const items: Item[] = [];
+      Object.entries(data as Record<string, any>).forEach(([month, monthData]) => {
+        if (monthData && Array.isArray(monthData.items) && typeof monthData.total === 'number') {
+          safeBudget[month] = monthData;
           items.push(...monthData.items);
-        });
-        setAllItems(items);
-        setLoading(false);
+        }
       });
+      setBudget(safeBudget);
+      setAllItems(items);
+      setLoadError(false);
+    } catch (error) {
+      console.error('Failed to fetch budget:', error);
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchBudget();
   }, []);
+
+  // 読み込み失敗時の再試行
+  const handleRetry = () => {
+    setLoadError(false);
+    setLoading(true);
+    fetchBudget();
+  };
 
   const toggleSelect = (id: number) => {
     const newSet = new Set(selectedIds);
@@ -65,6 +91,20 @@ export default function BudgetView() {
 
   if (loading) {
     return <div className="text-gray-500 dark:text-gray-400">読み込み中...</div>;
+  }
+
+  if (loadError) {
+    return (
+      <div className="text-gray-500 dark:text-gray-400 text-center py-8">
+        <p>読み込みに失敗しました</p>
+        <button
+          onClick={handleRetry}
+          className="mt-3 px-4 py-2 text-sm text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 rounded-lg transition-colors"
+        >
+          再試行
+        </button>
+      </div>
+    );
   }
 
   // undatedを除いた月をソート

--- a/src/components/TrashView.tsx
+++ b/src/components/TrashView.tsx
@@ -11,17 +11,35 @@ interface TrashItem extends Item {
 export default function TrashView() {
   const [items, setItems] = useState<TrashItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
 
   const fetchItems = async () => {
-    const res = await fetch('/api/trash');
-    const data = await res.json();
-    setItems(data);
-    setLoading(false);
+    try {
+      const res = await fetch('/api/trash');
+      if (!res.ok) throw new Error(`Failed to fetch trash: ${res.status}`);
+      const data = await res.json();
+      // 非配列レスポンス（エラーJSON等）を配列stateに入れない
+      if (!Array.isArray(data)) throw new Error('Unexpected response format');
+      setItems(data);
+      setLoadError(false);
+    } catch (error) {
+      console.error('Failed to fetch trash:', error);
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
   };
 
   useEffect(() => {
     fetchItems();
   }, []);
+
+  // 読み込み失敗時の再試行
+  const handleRetry = () => {
+    setLoadError(false);
+    setLoading(true);
+    fetchItems();
+  };
 
   const handleRestore = async (id: number) => {
     await fetch(`/api/trash/${id}`, { method: 'POST' });
@@ -42,6 +60,20 @@ export default function TrashView() {
 
   if (loading) {
     return <div className="text-center py-8 text-slate-500 dark:text-slate-400">読み込み中...</div>;
+  }
+
+  if (loadError) {
+    return (
+      <div className="text-center py-8 text-slate-500 dark:text-slate-400">
+        <p>読み込みに失敗しました</p>
+        <button
+          onClick={handleRetry}
+          className="mt-3 px-4 py-2 text-sm text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 rounded-lg transition-colors"
+        >
+          再試行
+        </button>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## 概要
src/app/page.tsx（一覧）、src/components/BudgetView.tsx（予算）、src/components/TrashView.tsx（ゴミ箱）の取得処理が res.ok 未確認・catch なしで、API エラー時に `.map is not a function` でクラッシュ、または無限「読み込み中...」になる問題を修正。

## 受け入れ条件
- /api/items・/api/budget・/api/trash の取得が !res.ok または例外のとき「読み込みに失敗しました」+「再試行」ボタンを表示し、再試行で復帰
- 非配列レスポンスで .map/.filter クラッシュしない
- tsc pass

## 変更内容
- 3コンポーネント共通パターン: `loadError` state + `handleRetry`、文言「読み込みに失敗しました」/「再試行」で統一
- 取得処理に try/catch + `!res.ok` チェックを追加。`finally` で必ず `setLoading(false)`
- page.tsx / TrashView: `Array.isArray` ガードで非配列レスポンスを配列 state に入れない
- BudgetView: 月キーオブジェクトを検証し、`items` が配列かつ `total` が number のエントリのみ採用（エラーJSON `{error:...}` 混入時もクラッシュしない）
- page.tsx の fetchGroups/fetchCategories は補助データのため、防御（res.ok + catch + Array.isArray）のみ追加し空配列のまま継続。エラーUIは出さない。一覧の再試行ボタンで併せて再取得
- 成功パス（データ表示、並び替え、選択等）の挙動は変更なし
- エラー表示は各画面の既存空状態/読み込み中スタイルに合わせた

## 確認
- `npx tsc --noEmit` pass
- `npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)